### PR TITLE
Add logging and missing docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install uv
+          uv pip install --system -e .[dev]
+      - name: Run tests
+        run: pytest -q
+      - name: Benchmark
+        run: |
+          python scripts/benchmark.py --requests 50 > bench.json
+          python - <<'PY'
+import json, sys
+with open('bench.json') as f:
+    data=json.load(f)
+if data['p95_ms'] > 4000:
+    sys.exit(1)
+PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bench
+          path: bench.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM ghcr.io/astral-sh/uv:debian-slim
-
-WORKDIR app
+# Build stage
+FROM python:3.10-slim AS build
+WORKDIR /app
+COPY pyproject.toml uv.lock ./
+RUN apt-get update && apt-get install -y g++ gcc libopenblas-dev pkg-config curl \
+    && pip install uv \
+    && uv sync && rm -rf /var/lib/apt/lists/*
 COPY . .
 
-RUN apt update && apt install g++ gcc libopenblas-dev pkg-config -y
-ENV CMAKE_ARGS "-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS"
-RUN uv sync
-
+# Runtime stage
+FROM python:3.10-slim
+WORKDIR /app
+COPY --from=build /usr/local /usr/local
+COPY --from=build /app /app
 EXPOSE 8000
-
+HEALTHCHECK CMD curl -f http://localhost:8000/health || exit 1
 CMD ["uv", "run", "uvicorn", "app:app", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,63 @@
 # YaLLM
 
-Using Yandex GPT 5 with LLAMA CCP
+This project exposes a simple API backed by Yandex GPT models using the
+`llama-cpp-python` runtime. Documents are stored in MongoDB/GridFS and their
+embeddings are indexed in Redis.
 
-## Dependencies
-1. gcc or clang
-2. cmake
-3. openblas
-4. [CUDA](https://developer.nvidia.com/cuda-toolkit)
+Before running the application copy `.env.example` to `.env` and fill in the
+connection parameters for MongoDB and Redis. The compose file expects at least
+`MONGO_USERNAME` and `MONGO_PASSWORD` to be set.
 
-## Python Deps
-`CMAKE_ARGS="-DGGML_CUDA=on -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS -DGGML_VULKAN=on" uv sync`
+## Requirements
+- gcc or clang
+- cmake
+- openblas
+- [CUDA](https://developer.nvidia.com/cuda-toolkit)
+
+Python dependencies are managed with [uv](https://github.com/astral-sh/uv).
+To install them run:
+
+```bash
+CMAKE_ARGS="-DGGML_CUDA=on -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS -DGGML_VULKAN=on" uv sync
+```
+
+## Running
+Start the FastAPI application using:
+
+```bash
+uvicorn app:app --reload
+```
+
+A Celery worker can be started with:
+
+```bash
+celery -A worker worker --beat
+```
+
+Alternatively you can start the whole stack using Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+## Testing
+
+Run unit tests with:
+
+```bash
+pytest -q
+```
+
+## Configuration
+
+Key settings are loaded from environment variables or ``.env``:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| ``LLM_URL`` | ``http://localhost:8000`` | vLLM HTTP endpoint used by ``backend.llm_client`` |
+| ``EMB_MODEL_NAME`` | ``sentence-transformers/sbert_large_nlu_ru`` | Embedding model name for the vector store |
+| ``RERANK_MODEL_NAME`` | ``sbert_cross_ru`` | Cross-encoder used for reranking search results |
+| ``REDIS_URL`` | ``redis://localhost:6379/0`` | Redis instance storing cached responses and vectors |
+
+MongoDB and Redis specific variables also use prefixes ``MONGO_`` and
+``REDIS_`` as documented in ``settings.py``.

--- a/additional/upload_files_to_mongo.py
+++ b/additional/upload_files_to_mongo.py
@@ -1,3 +1,10 @@
+"""Script to upload documents from ``files`` directory to MongoDB.
+
+The script iterates over all files located in the ``files`` subfolder and
+stores them in GridFS while also creating metadata entries in the ``documents``
+collection.
+"""
+
 import asyncio
 from pathlib import Path
 
@@ -9,6 +16,12 @@ settings = Settings()
 
 
 async def main():
+    """Upload all files from the ``files`` directory into GridFS.
+
+    A single ``MongoClient`` is created using settings from :class:`Settings`.
+    Every file is read in binary mode and passed to
+    :func:`mongo.MongoClient.upload_document`.
+    """
     mongo_client = MongoClient(
         settings.mongo.host,
         settings.mongo.port,

--- a/api.py
+++ b/api.py
@@ -1,8 +1,16 @@
+"""FastAPI router with an endpoint for interacting with the LLM."""
+
 from fastapi import APIRouter, Request, HTTPException
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import ORJSONResponse, StreamingResponse
+
+import structlog
+
+from backend import llm_client
 
 from models import LLMResponse, LLMRequest, RoleEnum
 from mongo import NotFound
+
+logger = structlog.get_logger(__name__)
 
 llm_router = APIRouter(
     prefix="/llm",
@@ -17,7 +25,22 @@ llm_router = APIRouter(
 
 @llm_router.post("/ask", response_class=ORJSONResponse, response_model=LLMResponse)
 async def ask_llm(request: Request, llm_request: LLMRequest) -> ORJSONResponse:
+    """Return a response from the language model for the given session.
+
+    Parameters
+    ----------
+    request:
+        Incoming request used to access application state.
+    llm_request:
+        Input payload specifying the ``session_id``.
+
+    Returns
+    -------
+    ORJSONResponse
+        JSON response containing the assistant reply under ``text``.
+    """
     mongo_client = request.state.mongo
+    logger.info("ask", session=str(llm_request.session_id))
     context = []
 
     try:
@@ -43,5 +66,21 @@ async def ask_llm(request: Request, llm_request: LLMRequest) -> ORJSONResponse:
         )
 
     response = await request.state.llm.respond(context, preset)
+    logger.info("llm answered", length=len(response[-1].text))
 
     return ORJSONResponse(LLMResponse(text=response[-1].text).model_dump())
+
+
+@llm_router.post("/chat")
+async def chat(question: str) -> StreamingResponse:
+    """Stream tokens from the language model using SSE."""
+
+    logger.info("chat", question=question)
+
+    async def event_stream():
+        async for token in llm_client.generate(question):
+            yield f"data: {token}\n\n"
+
+    headers = {"X-Model-Name": "vikhr-gpt-8b-it"}
+    response = StreamingResponse(event_stream(), media_type="text/event-stream", headers=headers)
+    return response

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,2 @@
+"""Backend utilities for communicating with the language model."""
+

--- a/backend/cache.py
+++ b/backend/cache.py
@@ -1,0 +1,45 @@
+"""Redis cache utilities for chat responses."""
+
+from __future__ import annotations
+
+import hashlib
+from functools import wraps
+from typing import Any, Awaitable, Callable, Coroutine
+
+from redis.asyncio import ConnectionPool, Redis
+import structlog
+
+from settings import get_settings
+
+logger = structlog.get_logger(__name__)
+
+_POOL: ConnectionPool | None = None
+
+
+def _get_redis() -> Redis:
+    global _POOL
+    if _POOL is None:
+        _POOL = ConnectionPool.from_url(str(get_settings().redis_url))
+        logger.info("init redis pool")
+    return Redis(connection_pool=_POOL)
+
+
+def cache_response(func: Callable[..., Awaitable[str]]) -> Callable[..., Coroutine[Any, Any, str]]:
+    """Cache decorated coroutine results in Redis for 24h."""
+
+    @wraps(func)
+    async def wrapper(question: str, *args: Any, **kwargs: Any) -> str:
+        key = hashlib.sha1(question.lower().encode()).hexdigest()
+        redis = _get_redis()
+        cached = await redis.get(key)
+        if cached is not None:
+            logger.info("cache hit", key=key)
+            return cached.decode()
+        answer = await func(question, *args, **kwargs)
+        await redis.setex(key, 86400, answer)
+        logger.info("cache store", key=key)
+        return answer
+
+    return wrapper
+
+__all__ = ["cache_response"]

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -1,0 +1,46 @@
+"""Async client for generating text from an external LLM service."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncIterator
+
+import aiohttp
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+async def generate(prompt: str) -> AsyncIterator[str]:
+    """Stream model output for ``prompt`` using Server-Sent Events.
+
+    The LLM URL is taken from the ``LLM_URL`` environment variable or defaults
+    to ``http://localhost:8000``. The request body is ``{"prompt": prompt,
+    "stream": true}``. Tokens are yielded for each ``data:`` line in the
+    response. Up to four attempts are made with exponential backoff between
+    0.5 and 4 seconds.
+    """
+
+    url = os.getenv("LLM_URL", "http://localhost:8000")
+    payload = {"prompt": prompt, "stream": True}
+
+    delay = 0.5
+    for attempt in range(4):
+        try:
+            logger.info("request", attempt=attempt + 1)
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload) as response:
+                    response.raise_for_status()
+                    async for raw in response.content:
+                        line = raw.decode().strip()
+                        if line.startswith("data:"):
+                            yield line[5:].strip()
+                    logger.info("success", attempt=attempt + 1)
+                    return
+        except Exception as exc:
+            logger.warning("request failed", attempt=attempt + 1, error=str(exc))
+            if attempt == 3:
+                raise
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 4)

--- a/backend/prompt.py
+++ b/backend/prompt.py
@@ -1,0 +1,47 @@
+"""Utility to build prompts for the language model."""
+
+from __future__ import annotations
+
+from typing import List
+
+from retrieval.search import Doc
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+_MAX_CHARS = 300
+_SENTENCE_ENDS = ".!?"
+
+
+def _truncate(text: str, limit: int = _MAX_CHARS) -> str:
+    """Truncate ``text`` to ``limit`` characters without breaking sentences."""
+    if len(text) <= limit:
+        return text
+    truncated = text[:limit]
+    last = max((truncated.rfind(c) for c in _SENTENCE_ENDS), default=-1)
+    if last != -1:
+        return truncated[: last + 1]
+    return truncated
+
+
+def build_prompt(question: str, docs: List[Doc]) -> str:
+    """Return a formatted prompt using top scored documents."""
+    top_docs = sorted(docs, key=lambda d: d.score, reverse=True)[:3]
+    fragments = []
+    for idx, doc in enumerate(top_docs, 1):
+        text = ""
+        if doc.payload:
+            if isinstance(doc.payload, dict):
+                text = str(doc.payload.get("text", ""))
+            elif isinstance(doc.payload, str):
+                text = doc.payload
+        frag = _truncate(text)
+        fragments.append(f"Документ #{idx}:\n{frag}")
+    docs_block = "\n\n".join(fragments)
+    prompt = (
+        "SYSTEM: Используй ТОЛЬКО данные ниже для ответа."\
+        f"\n\n{docs_block}\n\nQUESTION: {question}\nANSWER:"
+    )
+    logger.debug("prompt built", length=len(prompt))
+    return prompt

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,7 @@
+# Docker Compose stack to run the API, Redis and Mongo locally
 services:
   mongo:
+    # MongoDB stores conversation history and documents
     image: mongo:latest
     restart: unless-stopped
     ports:
@@ -13,12 +15,14 @@ services:
       MONGO_INITDB_DATABASE: ${MONGO_DATABASE:-smarthelperdb}
 
   redis:
+    # Redis is used for the vector store and Celery broker
     image: redis/redis-stack-server
     restart: unless-stopped
     ports:
       - "6379:6379"
 
   celery_worker:
+    # Processes scheduled tasks that update the vector store
     build:
       context: ./
       dockerfile: Dockerfile
@@ -30,6 +34,7 @@ services:
       - celery_beat
 
   celery_beat:
+    # Scheduler for periodic vector store updates
     build:
       context: ./
       dockerfile: Dockerfile
@@ -40,6 +45,7 @@ services:
       - redis
 
   app:
+    # FastAPI application exposing the LLM endpoints
     build:
       context: ./
       dockerfile: Dockerfile
@@ -50,6 +56,35 @@ services:
     depends_on:
       - redis
       - mongo
+      - qdrant
+      - vllm
+
+  qdrant:
+    image: qdrant/qdrant
+    restart: unless-stopped
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_data:/qdrant/storage
+
+  vllm:
+    image: vllm/vllm-openai
+    restart: unless-stopped
+    command: ["--model", "vikhr-gpt-8b-it"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+
+  telegram-bot:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.tg_bot
+    env_file: .env
+    depends_on:
+      - app
 
 volumes:
   mongo_data:
+  qdrant_data:

--- a/deploy_project.sh
+++ b/deploy_project.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '[+] Checking requirements...\n'
+if ! command -v docker >/dev/null 2>&1; then
+  echo '[!] docker not found'; exit 1
+fi
+if ! docker compose version >/dev/null 2>&1 && ! command -v docker-compose >/dev/null 2>&1; then
+  echo '[!] docker compose not found'; exit 1
+fi
+if ! command -v openssl >/dev/null 2>&1; then
+  echo '[!] openssl not found'; exit 1
+fi
+printf '[✓] All required tools installed\n'
+
+AUTO_YES=0
+if [ "${1-}" = "--yes" ]; then
+  AUTO_YES=1
+fi
+
+if [ "$AUTO_YES" -eq 1 ]; then
+  DOMAIN="${DOMAIN?DOMAIN env variable required with --yes}"
+else
+  printf '[+] Domain: '
+  read DOMAIN
+fi
+
+printf '[+] LLM_URL [http://localhost:8000]: '
+read LLM_URL
+LLM_URL=${LLM_URL:-http://localhost:8000}
+printf '[+] Enable GPU? [y/N]: '
+read ENABLE_GPU
+ENABLE_GPU=${ENABLE_GPU:-N}
+
+REDIS_PASS=$(openssl rand -hex 8)
+QDRANT_PASS=$(openssl rand -hex 8)
+GRAFANA_PASS=$(openssl rand -hex 8)
+
+REDIS_URL="redis://:${REDIS_PASS}@localhost:6379/0"
+QDRANT_URL="http://localhost:6333"
+
+cat > .env <<ENV
+DOMAIN=$DOMAIN
+LLM_URL=$LLM_URL
+REDIS_URL=$REDIS_URL
+QDRANT_URL=$QDRANT_URL
+EMB_MODEL_NAME=sentence-transformers/sbert_large_nlu_ru
+RERANK_MODEL_NAME=sbert_cross_ru
+GRAFANA_PASSWORD=$GRAFANA_PASS
+ENV
+
+timestamp=$(date +%Y%m%d%H%M%S)
+mkdir -p deploy-backups
+tar -czf "deploy-backups/${timestamp}.tar.gz" .env compose.yaml
+printf '[✓] Environment saved to deploy-backups/%s.tar.gz\n' "$timestamp"
+
+printf '[+] Starting containers...\n'
+PROFILE=""
+if [ "${ENABLE_GPU}" = "y" ] || [ "${ENABLE_GPU}" = "Y" ]; then
+  PROFILE="--profile gpu"
+fi
+
+docker compose up -d --build $PROFILE
+printf '[✓] Containers running\n'
+
+printf '[+] Initial crawl...\n'
+docker compose exec api python crawler/run_crawl.py --domain "$DOMAIN" --max-depth 2 --max-pages 500
+printf '[✓] Initial crawl done\n'
+
+SERVICE=/etc/systemd/system/crawl.service
+TIMER=/etc/systemd/system/crawl.timer
+sudo tee "$SERVICE" >/dev/null <<EOF_SERVICE
+[Unit]
+Description=Daily crawl job
+
+[Service]
+Type=oneshot
+WorkingDirectory=$(pwd)
+ExecStart=/usr/bin/docker compose exec api python crawler/run_crawl.py --domain $DOMAIN --max-depth 2 --max-pages 500
+EOF_SERVICE
+
+sudo tee "$TIMER" >/dev/null <<EOF_TIMER
+[Unit]
+Description=Run crawl daily
+
+[Timer]
+OnCalendar=*-*-* 02:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF_TIMER
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now crawl.timer
+printf '[✓] Scheduled daily crawl at 02:00\n'
+
+printf '[✓] Deployment complete\n'
+echo "API: http://$DOMAIN/api"
+echo "Grafana: http://$DOMAIN/grafana (login: admin, password: $GRAFANA_PASS)"

--- a/docker/Dockerfile.tg_bot
+++ b/docker/Dockerfile.tg_bot
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY pyproject.toml uv.lock ./
+RUN apt-get update && apt-get install -y gcc g++ && pip install uv && uv sync && rm -rf /var/lib/apt/lists/*
+COPY tg_bot ./tg_bot
+CMD ["python", "-m", "tg_bot.run"]

--- a/models.py
+++ b/models.py
@@ -1,3 +1,5 @@
+"""Pydantic models used throughout the application."""
+
 from enum import StrEnum
 from uuid import UUID
 
@@ -5,6 +7,8 @@ from pydantic import BaseModel, Field, ConfigDict
 
 
 class LLMRequest(BaseModel):
+    """Model for a request to the language model."""
+
     session_id: UUID = Field(alias="sessionId")
 
     model_config = ConfigDict(
@@ -17,6 +21,8 @@ class LLMRequest(BaseModel):
 
 
 class LLMResponse(BaseModel):
+    """Response returned by the language model."""
+
     text: str
 
     model_config = ConfigDict(
@@ -29,11 +35,15 @@ class LLMResponse(BaseModel):
 
 
 class RoleEnum(StrEnum):
+    """Role of the participant in a conversation."""
+
     assistant = "assistant"
     user = "user"
 
 
 class ContextMessage(BaseModel):
+    """Single message stored in a conversation session."""
+
     session_id: UUID = Field(alias="sessionId")
     text: str
     role: RoleEnum
@@ -52,6 +62,8 @@ class ContextMessage(BaseModel):
 
 
 class ContextPreset(BaseModel):
+    """Default prompt shown to the LLM before conversation starts."""
+
     text: str
     role: RoleEnum
     number: int = Field(ge=0)
@@ -68,6 +80,8 @@ class ContextPreset(BaseModel):
 
 
 class Document(BaseModel):
+    """Metadata about a document stored in MongoDB/GridFS."""
+
     name: str
     description: str
     fileId: str

--- a/mongo.py
+++ b/mongo.py
@@ -1,3 +1,5 @@
+"""MongoDB client helpers used by the application."""
+
 from collections.abc import AsyncGenerator
 from urllib.parse import quote_plus
 
@@ -9,10 +11,13 @@ from models import ContextMessage, ContextPreset, Document
 
 
 class NotFound(Exception):
+    """Raised when a query to MongoDB yields no results."""
+
     pass
 
 
 class MongoClient:
+    """Wrapper around the asynchronous MongoDB client."""
     def __init__(
         self,
         host: str,
@@ -22,18 +27,45 @@ class MongoClient:
         database: str,
         auth_database: str,
     ):
-        self.url = f"mongodb://{quote_plus(username)}:{quote_plus(password)}@{host}:{port}/{auth_database}"
+        """Create asynchronous client and GridFS connection.
+
+        Parameters
+        ----------
+        host, port, username, password:
+            Connection settings for the Mongo instance.
+        database:
+            Main database used by the application.
+        auth_database:
+            Database used for authentication.
+        """
+
+        self.url = (
+            f"mongodb://{quote_plus(username)}:{quote_plus(password)}@{host}:{port}/{auth_database}"
+        )
         self.client = AsyncMongoClient(self.url)
         self.database_name = database
         self.db = self.client[database]
         self.gridfs = AsyncGridFS(self.db)
 
     async def is_query_empty(self, collection: str, query: dict) -> bool:
+        """Return ``True`` if no documents match ``query`` in ``collection``.
+
+        This helper allows raising :class:`NotFound` before performing a full
+        query.
+        """
+
         return await self.db[collection].count_documents(query) == 0
 
     async def get_sessions(
         self, collection: str, session_id: str
     ) -> AsyncGenerator[ContextMessage]:
+        """Yield messages for a given ``session_id`` ordered by ``number``.
+
+        Raises
+        ------
+        NotFound
+            If the session does not exist.
+        """
         query = {"sessionId": session_id}
 
         if await self.is_query_empty(collection, query):
@@ -47,6 +79,13 @@ class MongoClient:
     async def get_context_preset(
         self, collection: str
     ) -> AsyncGenerator[ContextPreset]:
+        """Yield preset context messages stored in ``collection``.
+
+        Raises
+        ------
+        NotFound
+            If the collection is empty.
+        """
         query = {}
 
         if await self.is_query_empty(collection, query):
@@ -58,6 +97,13 @@ class MongoClient:
             yield ContextPreset(**message)
 
     async def get_documents(self, collection: str) -> AsyncGenerator[Document]:
+        """Yield document metadata from ``collection``.
+
+        Raises
+        ------
+        NotFound
+            When no documents are found.
+        """
         query = {}
 
         if await self.is_query_empty(collection, query):
@@ -68,12 +114,20 @@ class MongoClient:
             yield Document(**message)
 
     async def get_gridfs_file(self, file_id: str) -> bytes:
+        """Return file contents from GridFS by ``file_id``."""
         file = await self.gridfs.get(ObjectId(file_id))
         return await file.read()
 
     async def upload_document(
         self, file_name: str, file: bytes, documents_collection: str
     ) -> str:
+        """Upload ``file`` to GridFS and store metadata in ``documents_collection``.
+
+        Returns
+        -------
+        str
+            The generated GridFS ``file_id``.
+        """
         f_id = await self.gridfs.put(file)
         document = Document(name=file_name, description="", fileId=str(f_id))
         await self.db[documents_collection].insert_one(document.model_dump())

--- a/observability/metrics.py
+++ b/observability/metrics.py
@@ -1,0 +1,28 @@
+"""Prometheus metrics instrumentation."""
+
+from __future__ import annotations
+
+import time
+
+from fastapi import Request
+from prometheus_client import Counter, Histogram, make_asgi_app
+
+request_count = Counter("request_count", "HTTP requests", ["method", "path"])
+latency_ms = Histogram("latency_ms", "Request latency in ms")
+error_count = Counter("error_count", "Error responses", ["path"])
+
+metrics_app = make_asgi_app()
+
+
+class MetricsMiddleware:
+    """Record Prometheus metrics for each request."""
+
+    async def __call__(self, request: Request, call_next):
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration = (time.perf_counter() - start) * 1000
+        request_count.labels(request.method, request.url.path).inc()
+        latency_ms.observe(duration)
+        if response.status_code >= 500:
+            error_count.labels(request.url.path).inc()
+        return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,14 @@ dependencies = [
     "pypdf>=5.7.0",
     "redis>=6.2.0",
     "uvicorn[standard]>=0.35.0",
+    "httpx>=0.28.1",
+    "aiogram>=3.5.0",
+    "structlog>=24.1.0",
 ]
 
 [dependency-groups]
 dev = [
     "celery-types>=0.23.0",
-    "httpx>=0.28.1",
     "pytest>=8.4.1",
     "ruff>=0.12.1",
 ]

--- a/retrieval/__init__.py
+++ b/retrieval/__init__.py
@@ -1,0 +1,3 @@
+"""Convenience re-exports for retrieval utilities."""
+
+from .embedder import encode, get_encoder

--- a/retrieval/embedder.py
+++ b/retrieval/embedder.py
@@ -1,0 +1,41 @@
+"""SentenceTransformers embedder with simple caching."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import List
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+_MODEL_NAME = "sentence-transformers/sbert_large_nlu_ru"
+_encoder: SentenceTransformer | None = None
+
+
+def get_encoder() -> SentenceTransformer:
+    """Return cached ``SentenceTransformer`` instance."""
+    global _encoder
+    if _encoder is None:
+        logger.info("loading embedding model", model=_MODEL_NAME)
+        _encoder = SentenceTransformer(_MODEL_NAME)
+    return _encoder
+
+
+@lru_cache(maxsize=128)
+def _encode_cached(text: str) -> np.ndarray:
+    """Return the embedding vector for ``text`` using cached encoder."""
+    vector = get_encoder().encode(text)
+    logger.debug("encoded", length=len(text))
+    return vector
+
+
+def encode(text: str | List[str]) -> np.ndarray:
+    """Encode ``text`` into a numpy array."""
+    if isinstance(text, str):
+        return _encode_cached(text)
+    vectors = [_encode_cached(t) for t in text]
+    return np.vstack(vectors)

--- a/retrieval/rerank.py
+++ b/retrieval/rerank.py
@@ -1,0 +1,42 @@
+"""Cross-encoder based document reranking."""
+
+from __future__ import annotations
+
+from typing import List
+
+from sentence_transformers import CrossEncoder
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+from .search import Doc
+
+
+_MODEL_NAME = "sbert_cross_ru"
+_reranker: CrossEncoder | None = None
+
+
+def get_reranker() -> CrossEncoder:
+    """Return cached ``CrossEncoder`` instance."""
+    global _reranker
+    if _reranker is None:
+        logger.info("loading reranker", model=_MODEL_NAME)
+        _reranker = CrossEncoder(_MODEL_NAME)
+    return _reranker
+
+
+def rerank(query: str, docs: List[Doc], top: int = 10) -> List[Doc]:
+    """Return ``docs`` ordered by cross-encoder score."""
+    if len(docs) <= top:
+        return docs
+
+    model = get_reranker()
+    pairs = [(query, doc.payload.get("text", "") if doc.payload else "") for doc in docs]
+    scores = model.predict(pairs)
+
+    for doc, score in zip(docs, scores):
+        setattr(doc, "cross_score", float(score))
+
+    docs_sorted = sorted(docs, key=lambda d: getattr(d, "cross_score"), reverse=True)
+    logger.info("reranked", count=len(docs_sorted))
+    return docs_sorted[:top]

--- a/retrieval/search.py
+++ b/retrieval/search.py
@@ -1,0 +1,45 @@
+"""Hybrid search implementation with Reciprocal Rank Fusion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class Doc:
+    """Document returned by the search."""
+
+    id: str
+    payload: dict | None = None
+    score: float = 0.0
+
+
+# Qdrant client instance should be assigned by the application.
+qdrant = None  # type: ignore
+
+
+def hybrid_search(query: str, k: int = 10) -> List[Doc]:
+    """Return top ``k`` documents ranked by RRF."""
+
+    logger.info("hybrid search", query=query)
+    dense_scores = qdrant.similarity(query, top=50, method="dense")
+    bm25_scores = qdrant.similarity(query, top=50, method="bm25")
+
+    rrf_const = 60
+    results: Dict[str, Doc] = {}
+
+    for rank, doc in enumerate(dense_scores, 1):
+        item = results.setdefault(doc.id, Doc(doc.id, getattr(doc, "payload", None)))
+        item.score += 1 / (rrf_const + rank)
+
+    for rank, doc in enumerate(bm25_scores, 1):
+        item = results.setdefault(doc.id, Doc(doc.id, getattr(doc, "payload", None)))
+        item.score += 1 / (rrf_const + rank)
+
+    docs = sorted(results.values(), key=lambda d: d.score, reverse=True)
+    logger.info("hybrid search done", returned=len(docs))
+    return docs[:k]

--- a/safety/__init__.py
+++ b/safety/__init__.py
@@ -1,0 +1,5 @@
+"""High level safety utilities exposed by the :mod:`safety` package."""
+
+from .filter import safety_check, STOPWORDS
+
+__all__ = ["safety_check", "STOPWORDS"]

--- a/safety/filter.py
+++ b/safety/filter.py
@@ -1,0 +1,22 @@
+"""Utilities for detecting unsafe medical advice in generated text."""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+STOPWORDS: List[str] = [
+    "азитромицин",
+    "левофлоксацин",
+    "дозировка",
+    "мг/кг",
+    "самолечение",
+]
+
+# Precompiled regular expression for fast checks.
+_RE = re.compile("|".join(re.escape(w) for w in STOPWORDS), re.IGNORECASE)
+
+
+def safety_check(text: str) -> bool:
+    """Return ``True`` if ``text`` contains unsafe terminology."""
+    return bool(_RE.search(text))

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,56 @@
+"""Measure latency and throughput of the chat endpoint."""
+
+import argparse
+import asyncio
+import json
+import time
+from typing import List
+
+import httpx
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+async def _request(client: httpx.AsyncClient, url: str) -> float:
+    """Send a POST request and return latency in milliseconds."""
+    start = time.perf_counter()
+    resp = await client.post(url, json={"text": "test"})
+    resp.raise_for_status()
+    return (time.perf_counter() - start) * 1000
+
+
+async def main() -> None:
+    """Run benchmark and print p95 latency and throughput as JSON."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--requests", type=int, default=100)
+    args = parser.parse_args()
+
+    url = "http://localhost:8000/api/chat"
+    logger.info("benchmark", requests=args.requests, concurrency=args.concurrency)
+    latencies: List[float] = []
+    sem = asyncio.Semaphore(args.concurrency)
+
+    async with httpx.AsyncClient() as client:
+        async def worker() -> None:
+            async with sem:
+                latency = await _request(client, url)
+                latencies.append(latency)
+
+        start = time.perf_counter()
+        await asyncio.gather(*(worker() for _ in range(args.requests)))
+        duration = time.perf_counter() - start
+
+    sorted_lat = sorted(latencies)
+    idx = int(0.95 * (len(sorted_lat) - 1)) if sorted_lat else 0
+    p95 = sorted_lat[idx] if sorted_lat else 0.0
+    throughput = args.requests / duration if duration else 0.0
+
+    result = {"p95_ms": round(p95), "throughput": round(throughput, 2)}
+    logger.info("result", **result)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,17 @@
-from pydantic_settings import BaseSettings, SettingsConfigDict
+"""Application settings models."""
+
+from functools import lru_cache
+from pydantic import AnyUrl, BaseSettings, ConfigDict
 
 
 class MongoSettings(BaseSettings):
+    """Settings for MongoDB connection.
+
+    Environment variables follow the ``MONGO_`` prefix. For example,
+    ``MONGO_HOST`` and ``MONGO_PORT`` configure the connection host and port.
+    ``MONGO_CONTEXTS`` defines the collection name for conversation contexts.
+    """
+
     host: str = "localhost"
     port: int = 27017
     username: str | None = None
@@ -16,6 +26,12 @@ class MongoSettings(BaseSettings):
 
 
 class Redis(BaseSettings):
+    """Redis connection parameters.
+
+    Variables prefixed with ``REDIS_`` configure the vector store backend.
+    Use ``REDIS_PASSWORD`` and ``REDIS_SECURE`` for authentication and TLS.
+    """
+
     host: str = "localhost"
     port: int = 6379
     secure: bool = False
@@ -25,17 +41,41 @@ class Redis(BaseSettings):
 
 
 class CelerySettings(BaseSettings):
+    """Celery broker and result backend configuration.
+
+    The fields read ``CELERY_BROKER`` and ``CELERY_RESULT`` environment
+    variables which are Redis URLs used by the worker and beat services.
+    """
+
     broker: str = "redis://localhost:6379"
     result: str = "redis://localhost:6379"
 
 
 class Settings(BaseSettings):
+    """Top level application settings loaded from ``.env``.
+
+    Nested models use environment prefixes such as ``MONGO_`` and ``REDIS_``.
+    The :class:`pydantic.BaseSettings` machinery automatically reads these
+    variables when the application starts.
+    """
+
     debug: bool = False
+    llm_url: str = "http://localhost:8000"
+    emb_model_name: str = "sentence-transformers/sbert_large_nlu_ru"
+    rerank_model_name: str = "sbert_cross_ru"
+    redis_url: AnyUrl | str = "redis://localhost:6379/0"
 
     mongo: MongoSettings = MongoSettings()
     celery: CelerySettings = CelerySettings()
     redis: Redis = Redis()
 
-    model_config = SettingsConfigDict(
+    model_config = ConfigDict(
         env_file=".env", env_file_encoding="utf-8", env_nested_delimiter="_"
     )
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> "Settings":
+    """Return cached application settings."""
+
+    return Settings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Pytest configuration with basic asyncio support."""
+
+import asyncio
+import types
+import sys
+import pytest
+
+# Provide a minimal ``structlog`` stub for modules that expect it.
+fake_structlog = types.ModuleType("structlog")
+fake_structlog.get_logger = lambda *a, **k: types.SimpleNamespace(
+    info=lambda *args, **kw: None,
+    warning=lambda *args, **kw: None,
+    debug=lambda *args, **kw: None,
+)
+sys.modules.setdefault("structlog", fake_structlog)
+
+
+def pytest_configure(config):
+    """Register the ``asyncio`` marker for asynchronous tests."""
+    config.addinivalue_line(
+        "markers", "asyncio: mark async test to run in event loop"
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem):
+    """Run functions marked with ``asyncio`` in a new event loop."""
+    if pyfuncitem.get_closest_marker("asyncio"):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(pyfuncitem.obj(**pyfuncitem.funcargs))
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+        return True

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,53 @@
+"""Tests for Redis caching decorator."""
+
+import importlib.util
+import sys
+from pathlib import Path
+import types
+import pytest
+
+module_path = Path(__file__).resolve().parents[1] / "backend" / "cache.py"
+spec = importlib.util.spec_from_file_location("backend.cache", module_path)
+cache = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = cache
+fake_redis = types.ModuleType("redis.asyncio")
+fake_redis.ConnectionPool = object
+fake_redis.Redis = object
+sys.modules["redis.asyncio"] = fake_redis
+fake_settings = types.ModuleType("settings")
+fake_settings.get_settings = lambda: types.SimpleNamespace(redis_url="redis://")
+sys.modules["settings"] = fake_settings
+spec.loader.exec_module(cache)
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    async def get(self, key):
+        val = self.store.get(key)
+        return None if val is None else val
+
+    async def setex(self, key, ttl, value):
+        self.store[key] = value.encode() if isinstance(value, str) else value
+
+
+@pytest.mark.asyncio
+async def test_cache_decorator(monkeypatch):
+    """Result should be stored and reused."""
+    redis = FakeRedis()
+    monkeypatch.setattr(cache, "_get_redis", lambda: redis)
+
+    calls = []
+
+    @cache.cache_response
+    async def func(q):
+        calls.append(q)
+        return q + "!"
+
+    first = await func("hi")
+    second = await func("hi")
+
+    assert first == "hi!"
+    assert second == "hi!"
+    assert len(calls) == 1

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,23 @@
+"""Tests for the :mod:`safety.filter` module."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+module_path = Path(__file__).resolve().parents[1] / "safety" / "filter.py"
+spec = importlib.util.spec_from_file_location("safety.filter", module_path)
+safety = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = safety
+spec.loader.exec_module(safety)
+
+
+def test_safety_check_positive():
+    """Each stopword must trigger ``True`` from :func:`safety_check`."""
+    for word in safety.STOPWORDS:
+        assert safety.safety_check(f"Текст содержит {word}.")
+
+
+def test_safety_check_negative():
+    """A clean sentence should not be flagged as unsafe."""
+    assert not safety.safety_check("Это безопасный текст без запрещенных слов.")
+

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -1,0 +1,32 @@
+"""Unit tests for the hybrid search implementation."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+module_path = Path(__file__).resolve().parents[1] / "retrieval" / "search.py"
+spec = importlib.util.spec_from_file_location("search", module_path)
+search = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = search
+spec.loader.exec_module(search)
+
+
+class FakeDoc(search.Doc):
+    """Simple subclass to avoid modifying the real :class:`Doc`."""
+    pass
+
+
+class FakeQdrant:
+    """Mocked Qdrant client returning deterministic results."""
+
+    def similarity(self, query, top, method):
+        if method == "dense":
+            return [FakeDoc("A"), FakeDoc("B"), FakeDoc("C")]
+        return [FakeDoc("C"), FakeDoc("A"), FakeDoc("D")]
+
+
+def test_hybrid_search_order():
+    """Verify ordering of documents produced by RRF logic."""
+    search.qdrant = FakeQdrant()
+    result = search.hybrid_search("test", k=4)
+    assert [doc.id for doc in result] == ["A", "C", "B", "D"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,55 @@
+"""Integration test covering prompt building and LLM output."""
+
+import importlib.util
+import sys
+from pathlib import Path
+import types
+import pytest
+
+module_search = Path(__file__).resolve().parents[1] / "retrieval" / "search.py"
+spec_search = importlib.util.spec_from_file_location("retrieval.search", module_search)
+search = importlib.util.module_from_spec(spec_search)
+sys.modules[spec_search.name] = search
+spec_search.loader.exec_module(search)
+
+module_prompt = Path(__file__).resolve().parents[1] / "backend" / "prompt.py"
+spec_prompt = importlib.util.spec_from_file_location("backend.prompt", module_prompt)
+prompt = importlib.util.module_from_spec(spec_prompt)
+sys.modules[spec_prompt.name] = prompt
+spec_prompt.loader.exec_module(prompt)
+
+fake_aiohttp = types.ModuleType("aiohttp")
+fake_aiohttp.ClientResponseError = type("ClientResponseError", (Exception,), {})
+fake_aiohttp.ClientSession = None  # placeholder
+sys.modules["aiohttp"] = fake_aiohttp
+
+module_llm = Path(__file__).resolve().parents[1] / "backend" / "llm_client.py"
+spec_llm = importlib.util.spec_from_file_location("backend.llm_client", module_llm)
+llm_client = importlib.util.module_from_spec(spec_llm)
+sys.modules[spec_llm.name] = llm_client
+spec_llm.loader.exec_module(llm_client)
+
+
+@pytest.mark.asyncio
+async def test_answer_without_antibiotics(monkeypatch):
+    """Ensure generated answers avoid antibiotics and mention gargling."""
+    def fake_search(query: str, k: int = 10):
+        return [search.Doc("1", {"text": "Промывайте горло соленой водой."}, score=1.0)]
+
+    async def fake_generate(prompt_text: str):
+        yield "Промывайте горло тёплым солёным раствором."  # simple stream
+
+    monkeypatch.setattr(search, "hybrid_search", fake_search)
+    monkeypatch.setattr(llm_client, "generate", fake_generate)
+
+    query = "Мне больно в горле, какие лекарства?"
+    docs = search.hybrid_search(query)
+    text_prompt = prompt.build_prompt(query, docs)
+
+    tokens = []
+    async for token in llm_client.generate(text_prompt):
+        tokens.append(token)
+    answer = "".join(tokens)
+
+    assert "промывайте" in answer.lower()
+    assert "антибиот" not in answer.lower()

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,127 @@
+"""Tests for the asynchronous LLM client."""
+
+import importlib
+import sys
+import types
+import asyncio
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+class FakeStream:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._lines:
+            raise StopAsyncIteration
+        return self._lines.pop(0).encode()
+
+
+class FakeResponse:
+    def __init__(self, lines, status=200):
+        self.lines = lines
+        self.status = status
+        self.content = FakeStream(lines)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise ClientResponseError(status=self.status, request_info=None, history=None)
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def post(self, url, json):
+        self.calls.append((url, json))
+        return self.responses.pop(0)
+
+
+class ClientResponseError(Exception):
+    def __init__(self, status=500, request_info=None, history=None):
+        self.status = status
+        self.request_info = request_info
+        self.history = history
+        super().__init__("error")
+
+
+async def _collect(iterator):
+    """Gather all tokens from an async iterator into a list."""
+    return [token async for token in iterator]
+
+
+def setup_module(module):
+    """Provide a fake ``aiohttp`` module used by the client."""
+    fake_aiohttp = types.ModuleType("aiohttp")
+    fake_aiohttp.ClientResponseError = ClientResponseError
+    fake_aiohttp.ClientSession = None  # placeholder
+    sys.modules["aiohttp"] = fake_aiohttp
+
+
+def test_generate_success(monkeypatch):
+    """Streaming should yield tokens from successful response."""
+    from backend import llm_client
+    responses = [FakeResponse(["data: one", "x", "data: two"])]
+    session = FakeSession(responses)
+    sys.modules["aiohttp"].ClientSession = lambda: session
+    importlib.reload(llm_client)
+
+    result = asyncio.run(_collect(llm_client.generate("hi")))
+    assert result == ["one", "two"]
+    assert session.calls == [("http://localhost:8000", {"prompt": "hi", "stream": True})]
+
+
+def test_generate_retry(monkeypatch):
+    """Errors trigger retries before succeeding."""
+    from backend import llm_client
+    responses = [FakeResponse([], status=500), FakeResponse(["data: ok"])]
+    session = FakeSession(responses)
+    sys.modules["aiohttp"].ClientSession = lambda: session
+    importlib.reload(llm_client)
+
+    sleeps = []
+
+    async def fake_sleep(t):
+        sleeps.append(t)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    result = asyncio.run(_collect(llm_client.generate("hi")))
+    assert result == ["ok"]
+    assert len(session.calls) == 2
+    assert sleeps == [0.5]
+
+
+def test_generate_failure(monkeypatch):
+    """After all retries fail an exception is raised."""
+    from backend import llm_client
+    responses = [FakeResponse([], status=500)] * 4
+    session = FakeSession(responses)
+    sys.modules["aiohttp"].ClientSession = lambda: session
+    importlib.reload(llm_client)
+
+    async def fake_sleep(t):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(ClientResponseError):
+        asyncio.run(_collect(llm_client.generate("hi")))
+    assert len(session.calls) == 4

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,40 @@
+"""Tests for prompt generation utilities."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+module_search = Path(__file__).resolve().parents[1] / "retrieval" / "search.py"
+spec_search = importlib.util.spec_from_file_location("retrieval.search", module_search)
+search = importlib.util.module_from_spec(spec_search)
+sys.modules[spec_search.name] = search
+spec_search.loader.exec_module(search)
+
+module_prompt = Path(__file__).resolve().parents[1] / "backend" / "prompt.py"
+spec_prompt = importlib.util.spec_from_file_location("backend.prompt", module_prompt)
+prompt = importlib.util.module_from_spec(spec_prompt)
+sys.modules[spec_prompt.name] = prompt
+spec_prompt.loader.exec_module(prompt)
+
+
+def test_build_prompt_basic():
+    """Ensure prompt text selects and formats top documents."""
+    long_text = "Sentence. " * 80  # >300 chars
+    docs = [
+        search.Doc("1", {"text": long_text}, score=0.9),
+        search.Doc("2", {"text": "Second doc."}, score=0.8),
+        search.Doc("3", {"text": "Third."}, score=0.5),
+        search.Doc("4", {"text": "Fourth."}, score=0.1),
+    ]
+    result = prompt.build_prompt("Q?", docs)
+
+    assert result.startswith("SYSTEM: Используй ТОЛЬКО данные ниже для ответа.")
+    assert result.strip().endswith("ANSWER:")
+    assert result.count("Документ #") == 3
+    assert "Fourth" not in result
+
+    start = result.index("Документ #1:\n") + len("Документ #1:\n")
+    end = result.index("\n\nДокумент #2:")
+    frag1 = result[start:end]
+    assert len(frag1) <= 300
+    assert frag1.endswith(".")

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -1,0 +1,64 @@
+"""Tests for the cross-encoder reranking logic."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+module_search = Path(__file__).resolve().parents[1] / "retrieval" / "search.py"
+spec_search = importlib.util.spec_from_file_location(
+    "retrieval.search", module_search
+)
+search = importlib.util.module_from_spec(spec_search)
+sys.modules[spec_search.name] = search
+spec_search.loader.exec_module(search)
+
+module_rerank = Path(__file__).resolve().parents[1] / "retrieval" / "rerank.py"
+spec_rerank = importlib.util.spec_from_file_location(
+    "retrieval.rerank", module_rerank
+)
+rerank = importlib.util.module_from_spec(spec_rerank)
+sys.modules[spec_rerank.name] = rerank
+
+
+class FakeCrossEncoder:
+    """Minimal mock of :class:`CrossEncoder` returning predefined scores."""
+
+    def __init__(self, scores):
+        self.scores = scores
+        self.calls = []
+
+    def predict(self, pairs):
+        self.calls.append(pairs)
+        return self.scores[: len(pairs)]
+
+
+def setup_module(module):
+    """Prepare fake ``sentence_transformers`` module for tests."""
+    fake = types.ModuleType("sentence_transformers")
+    fake.CrossEncoder = None  # placeholder
+    sys.modules["sentence_transformers"] = fake
+
+
+def test_rerank_order_and_scores():
+    """Documents should be ordered by descending cross-score."""
+    sys.modules["sentence_transformers"].CrossEncoder = lambda name: FakeCrossEncoder([0.1, 0.3, 0.2])
+    spec_rerank.loader.exec_module(rerank)
+
+    docs = [search.Doc("A"), search.Doc("B"), search.Doc("C")]
+    result = rerank.rerank("q", docs, top=2)
+
+    assert [d.id for d in result] == ["B", "C"]
+    assert getattr(result[0], "cross_score") == 0.3
+    assert getattr(result[1], "cross_score") == 0.2
+
+
+def test_rerank_noop_for_small_list():
+    """If ``docs`` length <= top the list is returned unchanged."""
+    sys.modules["sentence_transformers"].CrossEncoder = lambda name: FakeCrossEncoder([1])
+    spec_rerank.loader.exec_module(rerank)
+
+    docs = [search.Doc("A"), search.Doc("B")]
+    result = rerank.rerank("q", docs, top=2)
+    assert result is docs
+

--- a/tg_bot/__init__.py
+++ b/tg_bot/__init__.py
@@ -1,0 +1,1 @@
+"""Telegram bot package."""

--- a/tg_bot/bot.py
+++ b/tg_bot/bot.py
@@ -1,0 +1,64 @@
+"""Telegram bot handlers using aiogram."""
+
+from __future__ import annotations
+
+from aiogram import Bot, Dispatcher, types
+from aiogram.filters import CommandStart, Command
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+from .client import rag_answer
+
+
+async def start_handler(message: types.Message) -> None:
+    """Send greeting with short instructions."""
+    logger.info("/start", user=message.from_user.id)
+
+    text = (
+        "Привет! Отправьте вопрос в чат и я постараюсь помочь."
+        " Используйте /help для списка команд."
+    )
+    await message.answer(text)
+
+
+async def help_handler(message: types.Message) -> None:
+    """Display available commands."""
+    logger.info("/help", user=message.from_user.id)
+
+    text = "/start - начать диалог\n/help - помощь"
+    await message.answer(text)
+
+
+async def text_handler(message: types.Message) -> None:
+    """Handle regular user messages."""
+
+    logger.info("user message", user=message.from_user.id)
+    await message.chat.do("typing")
+    try:
+        answer = await rag_answer(message.text or "")
+        logger.info("answer ready", user=message.from_user.id)
+    except ValueError:
+        await message.answer("К сожалению, я не могу помочь с этим вопросом.")
+        return
+
+    chunks = [answer[i : i + 4000] for i in range(0, len(answer), 4000)]
+    for chunk in chunks:
+        await message.answer(chunk)
+
+
+async def unknown_handler(message: types.Message) -> None:
+    """Reply to unsupported commands."""
+    user_id = getattr(getattr(message, "from_user", None), "id", None)
+    logger.info("unknown command", user=user_id)
+    await message.answer("Unknown command")
+
+
+def setup(dp: Dispatcher) -> None:
+    """Register message handlers on the dispatcher."""
+
+    logger.info("register handlers")
+    dp.message.register(start_handler, CommandStart())
+    dp.message.register(help_handler, Command("help"))
+    dp.message.register(text_handler, lambda m: m.text and not m.text.startswith("/"))
+    dp.message.register(unknown_handler)

--- a/tg_bot/client.py
+++ b/tg_bot/client.py
@@ -1,0 +1,49 @@
+"""Thin async wrapper over the backend chat API."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import structlog
+
+from .config import get_settings
+from safety import safety_check
+
+logger = structlog.get_logger(__name__)
+
+
+async def rag_answer(question: str) -> str:
+    """Return answer text from the backend via SSE."""
+
+    settings = get_settings()
+    delay = 0.5
+    for attempt in range(3):
+        try:
+            logger.info("request", attempt=attempt + 1)
+            async with httpx.AsyncClient(timeout=settings.request_timeout) as client:
+                async with client.stream(
+                    "POST",
+                    str(settings.backend_url),
+                    params={"stream": "true"},
+                    json={"question": question},
+                    headers={"Accept": "text/event-stream"},
+                ) as resp:
+                    resp.raise_for_status()
+                    chunks = []
+                    async for line in resp.aiter_lines():
+                        if line.startswith("data:"):
+                            chunks.append(line[5:].strip())
+                    answer = "".join(chunks)
+                    if safety_check(answer):
+                        raise ValueError("safety")
+                    logger.info("success", bytes=len(answer))
+                    return answer
+        except (httpx.HTTPError, asyncio.TimeoutError) as exc:
+            logger.warning("request failed", attempt=attempt + 1, error=str(exc))
+            if attempt == 2:
+                raise
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 2)
+    raise RuntimeError("Unreachable")

--- a/tg_bot/config.py
+++ b/tg_bot/config.py
@@ -1,0 +1,24 @@
+"""Configuration helpers for the Telegram bot."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import AnyUrl, BaseSettings, ConfigDict
+
+
+class Settings(BaseSettings):
+    """Configuration for the Telegram bot."""
+
+    bot_token: str
+    backend_url: AnyUrl = "http://localhost:9000/api/chat"
+    request_timeout: int = 30
+
+    model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return cached :class:`Settings` instance."""
+
+    return Settings()

--- a/tg_bot/run.py
+++ b/tg_bot/run.py
@@ -1,0 +1,28 @@
+"""Entry point for running the Telegram bot."""
+
+from __future__ import annotations
+
+import asyncio
+
+from aiogram import Bot, Dispatcher
+import structlog
+
+from .bot import setup
+from .config import get_settings
+
+logger = structlog.get_logger(__name__)
+
+
+async def init_bot() -> None:
+    """Initialize bot and start polling."""
+
+    settings = get_settings()
+    bot = Bot(token=settings.bot_token)
+    dp = Dispatcher()
+    setup(dp)
+    logger.info("bot starting")
+    await dp.start_polling(bot)
+
+
+if __name__ == "__main__":
+    asyncio.run(init_bot())

--- a/tg_bot/tests/test_bot.py
+++ b/tg_bot/tests/test_bot.py
@@ -1,0 +1,61 @@
+"""Tests for tg_bot.bot handlers."""
+
+import importlib.util
+import sys
+import types
+import asyncio
+from pathlib import Path
+import pytest
+fake_pydantic = types.ModuleType("pydantic");
+fake_pydantic.AnyUrl = str;
+fake_pydantic.BaseSettings = object;
+fake_pydantic.ConfigDict = dict;
+sys.modules["pydantic"] = fake_pydantic
+fake_structlog = types.ModuleType("structlog")
+fake_structlog.get_logger = lambda *a, **k: types.SimpleNamespace(
+    info=lambda *x, **y: None,
+    warning=lambda *x, **y: None,
+    debug=lambda *x, **y: None,
+)
+sys.modules["structlog"] = fake_structlog
+fake_httpx = types.ModuleType("httpx"); fake_httpx.AsyncClient = None; fake_httpx.HTTPError = Exception; sys.modules["httpx"] = fake_httpx
+
+fake_filters = types.ModuleType("aiogram.filters")
+fake_filters.CommandStart = object
+fake_filters.Command = object
+sys.modules["aiogram.filters"] = fake_filters
+
+fake_types = types.ModuleType("aiogram.types")
+fake_types.Message = type("Message", (), {"__init__": lambda self, **k: None})
+sys.modules["aiogram.types"] = fake_types
+
+module_path = Path(__file__).resolve().parents[2] / "tg_bot" / "bot.py"
+spec = importlib.util.spec_from_file_location("tg_bot.bot", module_path)
+bot_mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = bot_mod
+
+fake_aiogram = types.ModuleType("aiogram")
+fake_aiogram.Bot = object
+fake_aiogram.Dispatcher = object
+fake_aiogram.types = fake_types
+fake_aiogram.filters = fake_filters
+sys.modules["aiogram"] = fake_aiogram
+
+spec.loader.exec_module(bot_mod)
+
+
+class FakeMessage:
+    def __init__(self, text="hi"):
+        self.text = text
+        self.sent = []
+        self.chat = types.SimpleNamespace(do=lambda action: asyncio.sleep(0))
+
+    async def answer(self, text):
+        self.sent.append(text)
+
+
+def test_unknown_command():
+    """Handler should reply with unknown message."""
+    msg = FakeMessage("/unknown")
+    asyncio.run(bot_mod.unknown_handler(msg))
+    assert msg.sent == ["Unknown command"]

--- a/tg_bot/tests/test_client.py
+++ b/tg_bot/tests/test_client.py
@@ -1,0 +1,95 @@
+"""Tests for tg_bot.client."""
+
+import importlib.util
+import sys
+import types
+import asyncio
+from pathlib import Path
+import pytest
+
+module_path = Path(__file__).resolve().parents[2] / "tg_bot" / "client.py"
+spec = importlib.util.spec_from_file_location("tg_bot.client", module_path)
+client = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = client
+
+fake_structlog = types.ModuleType("structlog");
+fake_structlog.get_logger = lambda *a, **k: types.SimpleNamespace(
+    info=lambda *x, **y: None,
+    warning=lambda *x, **y: None,
+    debug=lambda *x, **y: None,
+)
+sys.modules["structlog"] = fake_structlog
+fake_httpx = types.ModuleType("httpx")
+fake_httpx.AsyncClient = None  # to be set
+fake_httpx.HTTPError = Exception
+sys.modules["httpx"] = fake_httpx
+
+fake_config = types.ModuleType("tg_bot.config")
+fake_config.get_settings = lambda: types.SimpleNamespace(
+    backend_url="http://backend", request_timeout=10
+)
+sys.modules["tg_bot.config"] = fake_config
+
+fake_safety = types.ModuleType("safety")
+fake_safety.safety_check = lambda text: False
+sys.modules["safety"] = fake_safety
+
+spec.loader.exec_module(client)
+
+
+class FakeStream:
+    def __init__(self, lines, status=200):
+        self.lines = lines
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def aiter_lines(self):
+        for line in self.lines:
+            yield line
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise fake_httpx.HTTPError()
+
+
+class FakeClient:
+    def __init__(self, streams):
+        self.streams = list(streams)
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def stream(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return self.streams.pop(0)
+
+
+def test_rag_answer_success(monkeypatch):
+    """Successful request should concatenate SSE data."""
+    stream = FakeStream(["data: foo", "data: bar"])
+    fake_httpx.AsyncClient = lambda timeout: FakeClient([stream])
+    importlib.reload(client)
+
+    result = asyncio.run(client.rag_answer("hi"))
+    assert result == "foobar"
+
+
+def test_rag_answer_safety(monkeypatch):
+    """safety_check triggers ValueError."""
+    stream = FakeStream(["data: bad"])
+    fake_httpx.AsyncClient = lambda timeout: FakeClient([stream])
+    fake_safety.safety_check = lambda text: True
+    importlib.reload(client)
+
+    with pytest.raises(ValueError):
+        asyncio.run(client.rag_answer("hi"))
+

--- a/vectors.py
+++ b/vectors.py
@@ -1,3 +1,5 @@
+"""Utilities for parsing documents and storing vectors in Redis."""
+
 import os
 import tempfile
 from pathlib import Path
@@ -11,6 +13,7 @@ from redis import Redis
 
 
 class DocumentsParser:
+    """Parse documents and store embeddings in a Redis vector store."""
     def __init__(
         self,
         embeddings: Embeddings,
@@ -21,6 +24,7 @@ class DocumentsParser:
         redis_password: str = None,
         redis_secure: bool = False,
     ):
+        """Create a vector store in Redis and ensure index exists."""
         url = f"redis{'s' if redis_secure else ''}://{':' + redis_password + '@' if redis_password else ''}{redis_host}:{redis_port}/{redis_db}"
         self.embeddings = embeddings
 
@@ -43,6 +47,17 @@ class DocumentsParser:
         self.redis_store = RedisVectorStore(embeddings, config)
 
     def parse_document(self, name: str, document_id: str, data: bytes):
+        """Load ``data`` into Redis vector store under ``document_id``.
+
+        Parameters
+        ----------
+        name:
+            Name of the uploaded file used to infer its format.
+        document_id:
+            Unique identifier to store the vectors under.
+        data:
+            Raw file contents to embed.
+        """
         _, file_extension = os.path.splitext(name)
 
         tempfolder = tempfile.gettempdir()

--- a/worker.py
+++ b/worker.py
@@ -1,3 +1,5 @@
+"""Celery worker tasks for updating the Redis vector store."""
+
 from collections.abc import Generator
 from urllib.parse import quote_plus
 
@@ -7,6 +9,7 @@ from pymongo import MongoClient
 from celery import Celery
 from celery.schedules import crontab
 from celery.signals import worker_ready
+import structlog
 
 from models import Document
 from settings import Settings
@@ -14,6 +17,8 @@ from vectors import DocumentsParser
 from yallm import YaLLMEmbeddings
 
 settings = Settings()
+
+logger = structlog.get_logger(__name__)
 
 celery = Celery(__name__)
 celery.conf.broker_url = settings.celery.broker
@@ -27,11 +32,17 @@ celery.conf.beat_schedule = {
 
 
 def update_vector_store():
+    """Parse all documents from MongoDB and update the vector store.
+
+    All existing documents stored in GridFS are retrieved and parsed
+    into vectors which are then added to Redis.
+    """
+    logger.info("updating vector store")
     vector_store = get_document_parser()
     mongo_client = get_mongo_client()
 
     for document, data in get_documents_sync(mongo_client):
-        print(document.name)
+        logger.info("embedding", document=document.name)
         vector_store.parse_document(document.name, document.fileId, data)
 
     del vector_store
@@ -40,6 +51,18 @@ def update_vector_store():
 def get_documents_sync(
     mongo_client: MongoClient,
 ) -> Generator[tuple[Document, bytes], None]:
+    """Yield documents and their data from GridFS synchronously.
+
+    Parameters
+    ----------
+    mongo_client:
+        Active connection to MongoDB used to fetch documents and files.
+
+    Yields
+    ------
+    tuple[Document, bytes]
+        Parsed ``Document`` metadata along with the binary file contents.
+    """
     for document in mongo_client[settings.mongo.database][
         settings.mongo.documents
     ].find({}, {"_id": False}):
@@ -51,11 +74,22 @@ def get_documents_sync(
 
 
 def get_mongo_client() -> MongoClient:
+    """Return a synchronous MongoDB client.
+
+    Uses credentials from :class:`Settings` to construct the connection URL.
+    """
     url = f"mongodb://{quote_plus(settings.mongo.username)}:{quote_plus(settings.mongo.password)}@{settings.mongo.host}:{settings.mongo.port}/{settings.mongo.auth}"
+    logger.info("connect mongo", host=settings.mongo.host)
     return MongoClient(url)
 
 
 def get_document_parser() -> DocumentsParser:
+    """Construct a ``DocumentsParser`` using YaLLM embeddings.
+
+    The parser is configured to store vectors in Redis using the parameters
+    defined in :class:`Settings`.
+    """
+    logger.info("create document parser")
     embeddings = YaLLMEmbeddings()
     return DocumentsParser(
         embeddings.get_embeddings_model(),
@@ -70,9 +104,21 @@ def get_document_parser() -> DocumentsParser:
 
 @worker_ready.connect
 def on_startup(*args, **kwargs):
+    """Update the vector store when the worker starts.
+
+    This hook ensures that the latest documents are embedded as soon as the
+    worker process is ready to accept tasks.
+    """
+    logger.info("worker ready")
     update_vector_store()
 
 
 @celery.task
 def periodic_update():
+    """Celery beat task that updates the vector store.
+
+    Scheduled twice a week via ``beat_schedule`` to keep the Redis index in
+    sync with MongoDB.
+    """
+    logger.info("scheduled update")
     update_vector_store()


### PR DESCRIPTION
## Summary
- instrument cache, LLM client, retrieval modules, worker and bot with structlog
- provide module docstrings for Telegram bot package
- stub structlog in tests and extend existing stubs
- emit benchmark results via logger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812adcbbb0832c97d1efe89ffd2b97