### PR TITLE
Pin container versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Alternatively you can start the whole stack using Docker Compose:
 ```bash
 docker compose up --build
 ```
+The compose file uses MongoDB `7` and Qdrant `v1.9` images.
 
 ## Testing
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ x-health: &health_defaults
 services:
   mongo:
     # MongoDB stores conversation history and documents
-    image: mongo:latest
+    image: mongo:7
     restart: unless-stopped
     ports:
       - "27017:27017"
@@ -108,7 +108,7 @@ services:
         - http://localhost:8000/health
 
   qdrant:
-    image: qdrant/qdrant
+    image: qdrant/qdrant:v1.9
     restart: unless-stopped
     ports:
       - "6333:6333"


### PR DESCRIPTION
## Summary
- pin MongoDB and Qdrant docker image tags
- note container versions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a80a00be0832cbd49da3357126d8b