### PR TITLE
Add qdrant healthcheck

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -98,7 +98,7 @@ services:
       mongo:
         condition: service_healthy
       qdrant:
-        condition: service_started
+        condition: service_healthy
     healthcheck:
       <<: *health_defaults
       test:
@@ -114,6 +114,13 @@ services:
       - "6333:6333"
     volumes:
       - qdrant_data:/qdrant/storage
+    healthcheck:
+      <<: *health_defaults
+      test:
+        - CMD
+        - curl
+        - -f
+        - http://localhost:6333/readyz
 
 
   telegram-bot:


### PR DESCRIPTION
## Summary
- run qdrant health checks using the same defaults as other services
- wait for qdrant to become healthy before starting the app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a809e604c832cb09fe4b8ec36b0ca