### PR TITLE
Enable GPU profile in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Alternatively you can start the whole stack using Docker Compose:
 docker compose up --build
 ```
 
+To enable GPU acceleration set `USE_GPU=true` in your `.env` file. The compose
+file will then start the `vllm` service by passing `--profile gpu` to
+`docker compose` via `deploy_project.sh`.
+
 ## Testing
 
 Run unit tests with:

--- a/compose.yaml
+++ b/compose.yaml
@@ -115,6 +115,23 @@ services:
     volumes:
       - qdrant_data:/qdrant/storage
 
+  vllm:
+    # Optional vLLM server used when ``USE_GPU=true``
+    profiles:
+      - gpu
+    image: vllm/vllm-openai:latest
+    env_file: .env
+    command:
+      - python
+      - -m
+      - vllm.entrypoints.openai.api_server
+      - --model
+      - ${LLM_MODEL}
+      - --host
+      - 0.0.0.0
+    ports:
+      - "8001:8000"
+
 
   telegram-bot:
     build:

--- a/deploy_project.sh
+++ b/deploy_project.sh
@@ -113,11 +113,11 @@ fi
 printf '[+] Starting containers...\n'
 if [ "$USE_GPU" = true ]; then
   echo '[+] Starting project in GPU mode'
+  docker compose --profile gpu up -d --build
 else
   echo '[+] Starting project in CPU mode'
+  docker compose up -d --build
 fi
-
-docker compose up -d --build
 printf '[✓] Containers running\n'
 
 if [ -d "./knowledge_base" ]; then


### PR DESCRIPTION
## Summary
- launch compose with `--profile gpu` when `USE_GPU=true`
- run vllm under the gpu profile in compose
- document the new GPU option for Docker deployment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a809c7334832cb163dccc95236d86