### PR TITLE
Fix vector cleanup; ignore venv

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ __pycache__
 .idea
 .vscode
 deploy-backups
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+
+# Python environment files
+.env
+
+# Editors
+.idea/
+.vscode/
+
+# Others
+*.log
+

--- a/vectors.py
+++ b/vectors.py
@@ -65,15 +65,18 @@ class DocumentsParser:
         with saved_file.open("wb") as tmp:
             tmp.write(data)
 
-        match file_extension:
-            case ".txt":
-                parser = TextLoader(saved_file)
-            case ".docx":
-                parser = Docx2txtLoader(saved_file)
-            case ".pdf":
-                parser = PyPDFLoader(file_path=tmp.name, mode="single")
-            case _:
-                raise ValueError("Unsupported file extension")
+        try:
+            match file_extension:
+                case ".txt":
+                    parser = TextLoader(saved_file)
+                case ".docx":
+                    parser = Docx2txtLoader(saved_file)
+                case ".pdf":
+                    parser = PyPDFLoader(file_path=tmp.name, mode="single")
+                case _:
+                    raise ValueError("Unsupported file extension")
 
-        document = parser.load()
-        self.redis_store.add_documents(document, ids=[document_id])
+            document = parser.load()
+            self.redis_store.add_documents(document, ids=[document_id])
+        finally:
+            saved_file.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- delete temporary files created when vectorizing
- exclude `.venv` from Docker context
- add project `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf96d23a8832cb4ec7dd077afdad7