### PR TITLE
Pin tg_bot Dockerfile to CPU llama-cpp wheel

### DIFF
--- a/docker/Dockerfile.tg_bot
+++ b/docker/Dockerfile.tg_bot
@@ -13,12 +13,11 @@ RUN apt-get update && \
         libopenblas-dev \
         python3-dev
 
-# Use a portable CPU build of llama-cpp-python
-ENV PIP_EXTRA_INDEX_URL=https://abetlen.github.io/llama-cpp-python/whl/cpu
-ENV FORCE_CMAKE=1
-ENV CMAKE_ARGS="-DLLAMA_CUBLAS=OFF -DLLAMA_METAL=OFF -DLLAMA_BLAS=OFF -DGGML_NO_SIMD=ON"
+# Prefer prebuilt CPU-only wheel for llama-cpp-python to avoid SIMD issues
+ENV PIP_INDEX_URL=https://pypi.org/simple \
+    PIP_EXTRA_INDEX_URL=https://abetlen.github.io/llama-cpp-python/whl/cpu
 
-RUN pip install --no-cache-dir "llama-cpp-python>=0.3.14,<0.4" && \
+RUN pip install --no-cache-dir "llama-cpp-python==0.3.2.post4" && \
     pip install --no-cache-dir uv && \
     uv sync && \
     apt-get purge -y --auto-remove git cmake build-essential python3-dev && \


### PR DESCRIPTION
## Summary
- point pip to CPU-only llama-cpp wheel index to bypass source builds
- pin tg_bot to llama-cpp-python 0.3.2.post4 for portable, SIMD-free runtime

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e1a517fa0832c9651df315262338e