### PR TITLE
Pin tg_bot to portable llama-cpp 0.3.14 wheel

### DIFF
--- a/docker/Dockerfile.tg_bot
+++ b/docker/Dockerfile.tg_bot
@@ -13,12 +13,11 @@ RUN apt-get update && \
         libopenblas-dev \
         python3-dev
 
-# Use a portable CPU build of llama-cpp-python
-ENV PIP_EXTRA_INDEX_URL=https://abetlen.github.io/llama-cpp-python/whl/cpu
-ENV FORCE_CMAKE=1
-ENV CMAKE_ARGS="-DLLAMA_CUBLAS=OFF -DLLAMA_METAL=OFF -DLLAMA_BLAS=OFF -DGGML_NO_SIMD=ON"
+# Use prebuilt CPU-only wheel for llama-cpp-python to avoid SIMD issues
+ENV PIP_EXTRA_INDEX_URL=https://abetlen.github.io/llama-cpp-python/whl/cpu \
+    CMAKE_ARGS="-DLLAMA_CUBLAS=OFF -DLLAMA_METAL=OFF -DLLAMA_BLAS=OFF -DGGML_NO_SIMD=ON"
 
-RUN pip install --no-cache-dir "llama-cpp-python>=0.3.14,<0.4" && \
+RUN pip install --no-cache-dir "llama-cpp-python==0.3.14" && \
     pip install --no-cache-dir uv && \
     uv sync && \
     apt-get purge -y --auto-remove git cmake build-essential python3-dev && \


### PR DESCRIPTION
## Summary
- route pip to CPU-only llama-cpp-python wheel index and disable GPU/BLAS/SIMD in CMake args
- pin tg_bot build to llama-cpp-python 0.3.14 for ARM-safe runtime

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e1a517fa0832c9651df315262338e