### PR TITLE
Serialize apt cache mounts to avoid lock contention

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,19 +7,27 @@ COPY pyproject.toml uv.lock ./
 # Increase timeout for large wheel downloads.
 ENV UV_HTTP_TIMEOUT=600
 
+# Allow configuring cache IDs for parallel builds.
+ARG APT_CACHE_ID=apt-cache-app
+ARG UV_CACHE_ID=uv-cache-app
+
 # Cache apt/uv downloads, remove stale locks, install build deps and sync Python deps.
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/root/.cache/uv \
-    rm -f /var/lib/apt/lists/lock \
-          /var/cache/apt/archives/lock \
-          /var/cache/apt/archives/partial/lock && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential git cmake ninja-build pkg-config curl libopenblas-dev python3-dev && \
-    pip install --no-cache-dir 'uv>=0.8' && \
-    uv pip sync --no-cache && \
-    apt-get purge -y --auto-remove git cmake build-essential python3-dev ninja-build && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=${APT_CACHE_ID} \
+    --mount=type=cache,target=/root/.cache/uv,sharing=locked,id=${UV_CACHE_ID} \
+    bash -euxo pipefail -c '\
+      export DEBIAN_FRONTEND=noninteractive; \
+      mkdir -p /var/cache/apt/archives/partial; \
+      rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/cache/apt/archives/partial/lock; \
+      for i in 1 2 3 4 5; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -y -o Dpkg::Use-Pty=0 --no-install-recommends install \
+          build-essential git cmake ninja-build pkg-config curl libopenblas-dev python3-dev && break || sleep 3; \
+      done; \
+      pip install --no-cache-dir "uv>=0.8"; \
+      uv pip install --system --no-cache --frozen -r pyproject.toml; \
+      apt-get purge -y --auto-remove git cmake build-essential python3-dev ninja-build; \
+      apt-get clean; rm -rf /var/lib/apt/lists/* \
+    '
 
 COPY . .
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -43,6 +43,9 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+      args:
+        APT_CACHE_ID: apt-cache-worker
+        UV_CACHE_ID: uv-cache-worker
     restart: unless-stopped
     env_file: .env
     environment:
@@ -68,6 +71,9 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+      args:
+        APT_CACHE_ID: apt-cache-beat
+        UV_CACHE_ID: uv-cache-beat
     restart: unless-stopped
     env_file: .env
     command: ["uv", "run", "celery", "-A", "worker", "beat", "--loglevel=INFO"]
@@ -79,6 +85,9 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+      args:
+        APT_CACHE_ID: apt-cache-app
+        UV_CACHE_ID: uv-cache-app
     restart: unless-stopped
     env_file: .env
     environment:

--- a/deploy_project.sh
+++ b/deploy_project.sh
@@ -120,7 +120,15 @@ else
   echo '[+] Starting project in CPU mode'
 fi
 
-docker compose up -d --build
+printf '[+] Building images sequentially...\n'
+for svc in app telegram-bot celery_worker celery_beat; do
+  if ! docker compose build --pull "$svc"; then
+    printf '[!] Failed to build %s\n' "$svc"
+    exit 1
+  fi
+done
+
+docker compose up -d
 printf '[✓] Containers running\n'
 
 if [ -d "./knowledge_base" ]; then

--- a/docker/Dockerfile.tg_bot
+++ b/docker/Dockerfile.tg_bot
@@ -6,18 +6,22 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 
 # Устанавливаем необходимые системные библиотеки, компиляторы и синхронизируем Python-зависимости
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/root/.cache/uv \
-    rm -f /var/lib/apt/lists/lock \
-          /var/cache/apt/archives/lock \
-          /var/cache/apt/archives/partial/lock && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential git cmake ninja-build pkg-config curl libopenblas-dev python3-dev && \
-    pip install --no-cache-dir 'uv>=0.8' && \
-    uv pip sync --no-cache && \
-    apt-get purge -y --auto-remove git cmake build-essential python3-dev ninja-build && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-tg \
+    --mount=type=cache,target=/root/.cache/uv,sharing=locked,id=uv-cache-tg \
+    bash -euxo pipefail -c '\
+      export DEBIAN_FRONTEND=noninteractive; \
+      mkdir -p /var/cache/apt/archives/partial; \
+      rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/cache/apt/archives/partial/lock; \
+      for i in 1 2 3 4 5; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -y -o Dpkg::Use-Pty=0 --no-install-recommends install \
+          build-essential git cmake ninja-build pkg-config curl libopenblas-dev python3-dev && break || sleep 3; \
+      done; \
+      pip install --no-cache-dir "uv>=0.8"; \
+      uv pip install --system --no-cache --frozen -r pyproject.toml; \
+      apt-get purge -y --auto-remove git cmake build-essential python3-dev ninja-build; \
+      apt-get clean; rm -rf /var/lib/apt/lists/* \
+    '
 
 # Задаём переменные окружения для pip и CMake
 ENV PIP_EXTRA_INDEX_URL=https://abetlen.github.io/llama-cpp-python/whl/cpu \


### PR DESCRIPTION
## Summary
- add locked cache mounts with retries to Dockerfile builds
- pass per-service cache IDs through compose
- build docker images sequentially in deploy script
- install dependencies from pyproject via `uv pip install`

## Testing
- `bash -n deploy_project.sh`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68989f5a97b8832c850eff1413b15821