### PR TITLE
feat: configure crawl start URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ REDIS_URL=redis://localhost:6379/0
 QDRANT_URL=http://localhost:6333
 USE_GPU=false
 DOMAIN=
+CRAWL_START_URL=https://mmvs.ru
 
 # MongoDB configuration
 MONGO_HOST=localhost

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,6 +50,7 @@ services:
     env_file: .env
     environment:
       MONGO_URI: ${MONGO_URI:-mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@mongo:27017}
+      CRAWL_START_URL: ${CRAWL_START_URL}
     command: ["uv", "run", "celery", "-A", "worker", "worker", "--loglevel=INFO"]
     depends_on:
       redis:
@@ -92,6 +93,7 @@ services:
     env_file: .env
     environment:
       MONGO_URI: ${MONGO_URI:-mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@mongo:27017}
+      CRAWL_START_URL: ${CRAWL_START_URL}
     ports:
       - "8000:8000"
     volumes:

--- a/deploy_project.sh
+++ b/deploy_project.sh
@@ -40,6 +40,10 @@ else
   read -r DOMAIN
 fi
 
+# Autodetect crawl start URL from DOMAIN if not provided
+: "${CRAWL_START_URL:=https://${DOMAIN}}"
+export CRAWL_START_URL
+
 printf '[+] Enable GPU? [y/N]: '
 read -r ENABLE_GPU
 ENABLE_GPU=${ENABLE_GPU:-N}
@@ -89,6 +93,7 @@ update_env_var() {
 }
 
 update_env_var DOMAIN "$DOMAIN"
+update_env_var CRAWL_START_URL "$CRAWL_START_URL"
 update_env_var LLM_MODEL "$LLM_MODEL"
 update_env_var REDIS_URL "$REDIS_URL"
 update_env_var QDRANT_URL "$QDRANT_URL"
@@ -143,14 +148,17 @@ PY
 fi
 
 printf '[+] Waiting for API health check...\n'
-if curl -sf http://localhost:8000/health >/dev/null; then
-  echo '[✓] API is healthy'
-else
-  echo '[!] API health check failed'
-fi
+for i in {1..40}; do
+  if docker compose exec -T app sh -c 'curl -fsS http://127.0.0.1:${PORT:-8000}/health >/dev/null'; then
+    echo "[✓] API healthy"
+    break
+  fi
+  sleep 3
+done || { echo "[!] API health check failed"; exit 1; }
 
 printf '[+] Initial crawl...\n'
-docker compose exec app python crawler/run_crawl.py --domain "$DOMAIN" --max-depth 2 --max-pages 500
+docker compose exec -e CRAWL_START_URL="${CRAWL_START_URL}" \
+  app python crawler/run_crawl.py --url "${CRAWL_START_URL}" --max-depth 2 --max-pages 500
 printf '[✓] Initial crawl done\n'
 
 SERVICE=/etc/systemd/system/crawl.service


### PR DESCRIPTION
## Summary
- derive `CRAWL_START_URL` from DOMAIN for deploy script
- expose `CRAWL_START_URL` to services via compose file and example env
- use internal curl loop for API health check and pass start URL to crawl

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898b8462bac832cbadefa841ef54dc9