### PR TITLE
feat: paraphrase queries with llm

### DIFF
--- a/tests/test_textnorm.py
+++ b/tests/test_textnorm.py
@@ -1,0 +1,32 @@
+import pytest
+
+from textnorm import rewrite_query
+from backend import cache as cache_mod
+from backend import llm_client
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    async def get(self, key):
+        return None
+
+    async def setex(self, key, ttl, value):
+        self.store[key] = value
+
+
+@pytest.mark.asyncio
+async def test_rewrite_changes_text(monkeypatch):
+    redis = FakeRedis()
+    monkeypatch.setattr(cache_mod, "_get_redis", lambda: redis)
+
+    async def fake_generate(prompt: str):
+        yield "rewritten"
+
+    monkeypatch.setattr(llm_client, "generate", fake_generate)
+
+    original = "some query"
+    rewritten = await rewrite_query(original)
+    assert rewritten == "rewritten"
+    assert rewritten != original


### PR DESCRIPTION
## Summary
- rewrite queries using `backend.llm_client` and cache results
- add test ensuring `rewrite_query` modifies typical input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5a00d8fb8832ca82cf39ff271b35e