### PR TITLE
Log session ID on HTTP errors

### DIFF
--- a/api.py
+++ b/api.py
@@ -51,6 +51,9 @@ async def ask_llm(request: Request, llm_request: LLMRequest) -> ORJSONResponse:
             )
         ]
     except NotFound:
+        logger.warning(
+            "preset not found", session=str(llm_request.session_id)
+        )
         raise HTTPException(status_code=404, detail="Preset not found")
     try:
         async for message in mongo_client.get_sessions(
@@ -58,9 +61,15 @@ async def ask_llm(request: Request, llm_request: LLMRequest) -> ORJSONResponse:
         ):
             context.append({"role": str(message.role), "content": message.text})
     except NotFound:
+        logger.warning(
+            "session not found", session=str(llm_request.session_id)
+        )
         raise HTTPException(status_code=404, detail="Can't find specified sessionId")
 
     if context[-1]["role"] == RoleEnum.assistant:
+        logger.error(
+            "incorrect session state", session=str(llm_request.session_id)
+        )
         raise HTTPException(
             status_code=500, detail="Incorrect session state in database"
         )

--- a/tests/test_api_logging.py
+++ b/tests/test_api_logging.py
@@ -1,0 +1,150 @@
+"""Ensure errors log session identifiers."""
+
+import importlib.util
+import sys
+import types
+import uuid
+from pathlib import Path
+import enum
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_session_id_logged_on_error(monkeypatch):
+    logs = []
+
+    # Structlog stub capturing logs
+    def get_logger(*a, **k):
+        return types.SimpleNamespace(
+            info=lambda *args, **kw: logs.append(("info", args, kw)),
+            warning=lambda *args, **kw: logs.append(("warning", args, kw)),
+            error=lambda *args, **kw: logs.append(("error", args, kw)),
+            exception=lambda *args, **kw: logs.append(("exception", args, kw)),
+        )
+
+    fake_structlog = types.ModuleType("structlog")
+    fake_structlog.get_logger = get_logger
+    monkeypatch.setitem(sys.modules, "structlog", fake_structlog)
+
+    # Minimal FastAPI stubs
+    fastapi = types.ModuleType("fastapi")
+
+    class Request:
+        def __init__(self, state):
+            self.state = state
+
+    class HTTPException(Exception):
+        def __init__(self, status_code, detail):
+            self.status_code = status_code
+            self.detail = detail
+
+    class APIRouter:
+        def __init__(self, *a, **k):
+            pass
+
+        def post(self, *a, **k):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def get(self, *a, **k):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    fastapi.APIRouter = APIRouter
+    fastapi.Request = Request
+    fastapi.HTTPException = HTTPException
+
+    responses = types.ModuleType("fastapi.responses")
+
+    class ORJSONResponse:
+        def __init__(self, content, *a, **k):
+            self.content = content
+
+    class StreamingResponse:
+        def __init__(self, *a, **k):
+            pass
+
+    responses.ORJSONResponse = ORJSONResponse
+    responses.StreamingResponse = StreamingResponse
+    fastapi.responses = responses
+
+    modules = {
+        "fastapi": fastapi,
+        "fastapi.responses": responses,
+    }
+
+    # mongo and models stubs
+    mongo = types.ModuleType("mongo")
+
+    class NotFound(Exception):
+        pass
+
+    mongo.NotFound = NotFound
+    modules["mongo"] = mongo
+
+    models_mod = types.ModuleType("models")
+
+    class RoleEnum(str, enum.Enum):
+        assistant = "assistant"
+        user = "user"
+
+    class LLMRequest:
+        def __init__(self, session_id):
+            self.session_id = session_id
+
+    class LLMResponse:
+        def __init__(self, text):
+            self.text = text
+
+        def model_dump(self):
+            return {"text": self.text}
+
+    models_mod.RoleEnum = RoleEnum
+    models_mod.LLMRequest = LLMRequest
+    models_mod.LLMResponse = LLMResponse
+    modules["models"] = models_mod
+
+    for name, mod in modules.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    # Import api after stubbing dependencies
+    module_path = Path(__file__).resolve().parents[1] / "api.py"
+    spec = importlib.util.spec_from_file_location("api", module_path)
+    api = importlib.util.module_from_spec(spec)
+    sys.modules["api"] = api
+    spec.loader.exec_module(api)
+
+    # Dummy mongo to trigger NotFound
+    class DummyMongo:
+        async def get_context_preset(self, collection):
+            yield types.SimpleNamespace(role=RoleEnum.user, text="preset")
+
+        async def get_sessions(self, collection, session_id):
+            raise NotFound
+            yield  # pragma: no cover
+
+    request = types.SimpleNamespace(
+        state=types.SimpleNamespace(
+            mongo=DummyMongo(),
+            contexts_collection="ctx",
+            context_presets_collection="preset",
+            llm=types.SimpleNamespace(respond=lambda *a, **k: None),
+        )
+    )
+
+    session = uuid.uuid4()
+    llm_request = LLMRequest(session)
+
+    with pytest.raises(HTTPException) as exc:
+        await api.ask_llm(request, llm_request)
+
+    assert exc.value.status_code == 404
+    assert any(
+        entry[2].get("session") == str(session) and entry[0] == "warning"
+        for entry in logs
+    )


### PR DESCRIPTION
## Summary
- log session ID with warnings for missing presets and sessions
- log session ID with error on incorrect session state
- add test ensuring session ID appears in logs when errors occur

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5a26b7c28832c84eb13d79db90fd2