### PR TITLE
Add healthcheck for qdrant service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -138,7 +138,7 @@ services:
       redis:
         condition: service_healthy
       qdrant:
-        condition: service_started
+        condition: service_healthy
 
   qdrant:
     image: qdrant/qdrant
@@ -147,6 +147,9 @@ services:
       - "6333:6333"
     volumes:
       - qdrant_data:/qdrant/storage
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "curl -fsS http://localhost:6333/ready || exit 1"]
 
 
   telegram-bot:


### PR DESCRIPTION
## Summary
- add healthcheck for the qdrant service
- wait for qdrant to be healthy before starting app

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'starlette')*


------
https://chatgpt.com/codex/tasks/task_e_68a5adde7200832c97af7a632dee7d0f