### PR TITLE
refactor: use unified BOT_TOKEN variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ MongoDB and Redis specific variables also use prefixes ``MONGO_`` and
 The optional Telegram bot can be started with Docker Compose. Set the
 following variables in ``.env``:
 
-* ``TG_BOT_TOKEN`` – bot token from BotFather.
+* ``BOT_TOKEN`` – bot token from BotFather.
 * ``TG_API_URL`` – URL of the backend chat API (usually ``http://api:8000/api/chat``).
 * ``SUPPORT_GROUP_ID`` – identifier of the operator group.
 

--- a/tg_bot/run.py
+++ b/tg_bot/run.py
@@ -15,9 +15,9 @@ from observability.logging import configure_logging
 configure_logging()
 logger = structlog.get_logger(__name__)
 
-TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+TOKEN = os.getenv("BOT_TOKEN", "").strip()
 if not TOKEN:
-    logger.warning("[telegram] TELEGRAM_BOT_TOKEN is empty — bot disabled")
+    logger.warning("[telegram] BOT_TOKEN is empty — bot disabled")
     sys.exit(0)
 
 from .bot import setup


### PR DESCRIPTION
## Summary
- refactor Telegram bot runner to read BOT_TOKEN env
- document BOT_TOKEN in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5adde37d4832c9c6888a02daee311