### PR TITLE
Switch cache to JSON serialization

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -40,7 +40,7 @@ class FakeRedis:
         return None if val is None else val
 
     async def setex(self, key, ttl, value):
-        self.store[key] = value.encode() if isinstance(value, str) else value
+        self.store[key] = value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace insecure pickle-based caching with JSON serialization
- add recursive helpers to serialize and deserialize common objects, including pydantic models
- adjust cache tests to match JSON-based storage

## Testing
- `pytest tests/test_cache.py -q`
- `pytest -q`
- `ruff check .` *(fails: E402, E703, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bbb09e60832c8b5cc7dd501a0b65