### PR TITLE
Refactor metrics middleware to use BaseHTTPMiddleware

### DIFF
--- a/observability/metrics.py
+++ b/observability/metrics.py
@@ -6,6 +6,7 @@ import time
 
 from fastapi import Request
 from prometheus_client import Counter, Histogram, make_asgi_app
+from starlette.middleware.base import BaseHTTPMiddleware
 
 request_count = Counter("request_count", "HTTP requests", ["method", "path"])
 latency_ms = Histogram("latency_ms", "Request latency in ms")
@@ -14,10 +15,10 @@ error_count = Counter("error_count", "Error responses", ["path"])
 metrics_app = make_asgi_app()
 
 
-class MetricsMiddleware:
+class MetricsMiddleware(BaseHTTPMiddleware):
     """Record Prometheus metrics for each request."""
 
-    async def __call__(self, request: Request, call_next):
+    async def dispatch(self, request: Request, call_next):
         """Measure latency and increment counters for ``request``."""
         start = time.perf_counter()
         response = await call_next(request)

--- a/tests/test_metrics_middleware.py
+++ b/tests/test_metrics_middleware.py
@@ -1,0 +1,11 @@
+"""Tests for MetricsMiddleware registration."""
+
+from starlette.applications import Starlette
+
+from observability.metrics import MetricsMiddleware
+
+
+def test_metrics_middleware_registration():
+    app = Starlette()
+    app.add_middleware(MetricsMiddleware)
+    assert any(m.cls is MetricsMiddleware for m in app.user_middleware)


### PR DESCRIPTION
## Summary
- refactor metrics middleware to derive from BaseHTTPMiddleware and move logic into `dispatch`
- add tests verifying metrics middleware registration with Starlette

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5bbacafcc832ca4acf1ae60b8b20c