### PR TITLE
Use async HTTP client for bot status handler

### DIFF
--- a/tg_bot/config.py
+++ b/tg_bot/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
 
     bot_token: str
     backend_url: AnyUrl = "http://localhost:9000/api/chat"
+    api_base_url: AnyUrl = "http://app:8000"
     request_timeout: int = 30
 
     model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")


### PR DESCRIPTION
## Summary
- switch `/status` handler to httpx.AsyncClient and config-based base URL
- expose `api_base_url` in Telegram bot settings
- test asynchronous status handler formatting

## Testing
- `ruff check tg_bot/bot.py tg_bot/config.py tg_bot/tests/test_bot.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5bbb16fa0832ca28c520bf21fd6d8