### PR TITLE
Ensure upload_document returns string ID

### DIFF
--- a/mongo.py
+++ b/mongo.py
@@ -156,8 +156,8 @@ class MongoClient:
         str
             The generated GridFS ``file_id``.
         """
-        f_id = str(await self.gridfs.put(file))
-        document = Document(name=file_name, description="", fileId=f_id)
+        f_id = await self.gridfs.put(file)
+        document = Document(name=file_name, description="", fileId=str(f_id))
         await self.db[documents_collection].insert_one(document.model_dump())
 
-        return f_id
+        return str(f_id)

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -1,7 +1,7 @@
 """Tests for MongoDB helpers."""
 
-import uuid
 import pytest
+from bson import ObjectId
 
 from mongo import MongoClient
 
@@ -9,7 +9,7 @@ from mongo import MongoClient
 class _FakeGridFS:
     """Minimal GridFS stub returning a predefined id."""
 
-    def __init__(self, f_id: uuid.UUID):
+    def __init__(self, f_id: ObjectId):
         self._id = f_id
 
     async def put(self, _file: bytes):  # pragma: no cover - simple stub
@@ -36,7 +36,7 @@ class _FakeDB:
 async def test_upload_document_returns_str() -> None:
     """``upload_document`` should return the file id as string."""
 
-    f_id = uuid.uuid4()
+    f_id = ObjectId()
     mc = MongoClient.__new__(MongoClient)
     mc.gridfs = _FakeGridFS(f_id)
     collection = _FakeCollection()


### PR DESCRIPTION
## Summary
- convert GridFS file ID to string before returning from `upload_document`
- test that `upload_document` yields a string file ID and stores the string in metadata

## Testing
- `pytest tests/test_mongo.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6074fd8dc832cbf7864eb5a5db430