### PR TITLE
refactor metrics middleware to extend BaseHTTPMiddleware

### DIFF
--- a/observability/metrics.py
+++ b/observability/metrics.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import time
 
+from collections.abc import Awaitable, Callable
+
 from fastapi import Request
 from prometheus_client import Counter, Histogram, make_asgi_app
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
 
 request_count = Counter("request_count", "HTTP requests", ["method", "path"])
 latency_ms = Histogram("latency_ms", "Request latency in ms")
@@ -18,7 +21,11 @@ metrics_app = make_asgi_app()
 class MetricsMiddleware(BaseHTTPMiddleware):
     """Record Prometheus metrics for each request."""
 
-    async def dispatch(self, request: Request, call_next):
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
         """Measure latency and increment counters for ``request``."""
         start = time.perf_counter()
         response = await call_next(request)

--- a/tests/test_metrics_middleware.py
+++ b/tests/test_metrics_middleware.py
@@ -1,6 +1,12 @@
-"""Tests for MetricsMiddleware registration."""
+"""Tests for ``MetricsMiddleware`` registration."""
+
+import sys
 
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
+
+# Ensure the ``fastapi`` stub provides ``Request`` for metrics import.
+sys.modules["fastapi"].Request = type("Request", (), {})
 
 from observability.metrics import MetricsMiddleware
 
@@ -8,4 +14,7 @@ from observability.metrics import MetricsMiddleware
 def test_metrics_middleware_registration():
     app = Starlette()
     app.add_middleware(MetricsMiddleware)
-    assert any(m.cls is MetricsMiddleware for m in app.user_middleware)
+    assert any(
+        isinstance(m, Middleware) and m.cls is MetricsMiddleware
+        for m in app.user_middleware
+    )


### PR DESCRIPTION
## Summary
- use BaseHTTPMiddleware for metrics collection with typed dispatch
- test that MetricsMiddleware registers correctly on a Starlette app

## Testing
- `pytest tests/test_metrics_middleware.py -q`
- `pytest tests/test_api_logging.py -q`
- `pytest -q` *(fails: No module named 'pydantic'; ImportError: cannot import name 'MongoClient' from 'mongo')*

------
https://chatgpt.com/codex/tasks/task_e_68a607517514832c8ef38242fc008372