### PR TITLE
Add crawler progress streaming and SSE admin page

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Crawler Progress</title>
+  <style>
+    body { font-family: sans-serif; }
+    pre { background: #f0f0f0; padding: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Crawler Progress</h1>
+  <pre id="output"></pre>
+  <script>
+    const output = document.getElementById('output');
+
+    function render(data) {
+      output.textContent = JSON.stringify(data, null, 2);
+    }
+
+    async function poll() {
+      try {
+        const resp = await fetch('/api/v1/crawler/status');
+        if (resp.ok) {
+          const json = await resp.json();
+          render(json);
+        }
+      } catch (err) {
+        console.error('Polling error', err);
+      }
+    }
+
+    if (window.EventSource) {
+      const es = new EventSource('/api/v1/crawler/stream');
+      es.onmessage = (e) => {
+        try {
+          render(JSON.parse(e.data));
+        } catch (err) {
+          console.error('Invalid SSE data', err);
+        }
+      };
+      es.onerror = () => {
+        es.close();
+        setInterval(poll, 2000);
+      };
+    } else {
+      setInterval(poll, 2000);
+    }
+  </script>
+</body>
+</html>

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ from fastapi.staticfiles import StaticFiles
 from observability.logging import configure_logging
 from observability.metrics import MetricsMiddleware, metrics_app
 
-from api import llm_router
+from api import llm_router, crawler_router
 from mongo import MongoClient
 from vectors import DocumentsParser
 from yallm import YaLLM, YaLLMEmbeddings
@@ -88,7 +88,12 @@ app.include_router(
     llm_router,
     prefix="/api/v1",
 )
+app.include_router(
+    crawler_router,
+    prefix="/api/v1",
+)
 app.mount("/widget", StaticFiles(directory="widget", html=True), name="widget")
+app.mount("/admin", StaticFiles(directory="admin", html=True), name="admin")
 
 
 def _mongo_ok() -> bool:


### PR DESCRIPTION
## Summary
- add `/crawler/stream` SSE endpoint and status endpoint
- expose crawler router and mount admin static page
- create admin page listening to crawler progress via EventSource

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'MongoClient' from 'mongo')*


------
https://chatgpt.com/codex/tasks/task_e_68a6b229a9bc832cb0613110e1e67dcf