### PR TITLE
Add Sphinx documentation skeleton with autodoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Run unit tests with:
 pytest -q
 ```
 
+## Documentation
+
+Build the HTML documentation with:
+
+```bash
+sphinx-build -b html docs build/docs
+```
+
 ## Configuration
 
 Key settings are loaded from environment variables or ``.env``:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,33 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+import sys
+sys.path.append("..")
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'sitellm_vertebro'
+copyright = '2025, sitellm developers'
+author = 'sitellm developers'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,63 @@
+.. sitellm_vertebro documentation master file, created by
+   sphinx-quickstart on Thu Aug 21 08:38:22 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+sitellm_vertebro documentation
+==============================
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+Modules
+-------
+
+Crawler
+~~~~~~~
+
+.. automodule:: crawler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Backend
+~~~~~~~
+
+.. automodule:: backend
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Core
+~~~~
+
+.. automodule:: core
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Retrieval
+~~~~~~~~~
+
+.. automodule:: retrieval
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Telegram Bot
+~~~~~~~~~~~~
+
+.. automodule:: tg_bot
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+API
+~~~
+
+.. automodule:: api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
## Summary
- set up Sphinx docs and enable autodoc
- document modules with automodule directives
- mention sphinx-build command in README

## Testing
- `sphinx-build -b html docs build/docs`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4', 'observability.metrics', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6da1b0c3c832c980471349cc13fc3