### PR TITLE
docs: expand env URLs and add regen comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,6 @@ DEBUG=false
 LLM_URL=http://localhost:8000
 EMB_MODEL_NAME=sentence-transformers/sbert_large_nlu_ru
 RERANK_MODEL_NAME=sbert_cross_ru
-REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
 QDRANT_URL=http://qdrant:6333
 DOMAIN=mmvs.ru
 
@@ -46,8 +45,10 @@ DOMAIN=mmvs.ru
 MONGO_HOST=mongo
 MONGO_PORT=27017
 MONGO_ROOT_USERNAME=root
+# Generate with: python -c "import secrets; print(secrets.token_hex(16))"
 MONGO_ROOT_PASSWORD=51c16BxU5Lm8520X
 MONGO_USERNAME=root
+# Generate with: python -c "import secrets; print(secrets.token_hex(16))"
 MONGO_PASSWORD=51c16BxU5Lm8520X
 MONGO_DATABASE=smarthelperdb
 MONGO_AUTH=admin
@@ -55,20 +56,26 @@ MONGO_CONTEXTS=contexts
 MONGO_PRESETS=contextPresets
 MONGO_VECTORS=vectors
 MONGO_DOCUMENTS=documents
+# Build using: mongodb://<user>:<password>@mongo:27017
 MONGO_URI=mongodb://root:51c16BxU5Lm8520X@mongo:27017
 
 # Redis options
 REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_SECURE=false
-REDIS_PASSWORD=371c47186a2c55c7
 REDIS_VECTOR=vector
+# Generate with: python -c "import secrets; print(secrets.token_hex(16))"
+REDIS_PASSWORD=371c47186a2c55c7
+# Build using: redis://:<password>@redis:6379/0
+REDIS_URL=redis://:371c47186a2c55c7@redis:6379/0
 
 # Celery broker settings
-CELERY_BROKER=redis://:${REDIS_PASSWORD}@redis:6379/0
-CELERY_RESULT=redis://:${REDIS_PASSWORD}@redis:6379/0
+# Build using the Redis URL above
+CELERY_BROKER=redis://:371c47186a2c55c7@redis:6379/0
+CELERY_RESULT=redis://:371c47186a2c55c7@redis:6379/0
 
 # Observability
+# Generate with: python -c "import secrets; print(secrets.token_hex(16))"
 GRAFANA_PASSWORD=c3a3448776605163
 
 # Telegram bot


### PR DESCRIPTION
## Summary
- clarify secret management in `.env.example`
- remove variable placeholders from Redis and Celery URLs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bson')*

------
https://chatgpt.com/codex/tasks/task_e_68acb0ea9588832ca8bf0be0612faebe