### PR TITLE
ci: lint with ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         run: |
           pip install uv
           uv pip install --system -e .[dev]
+      - name: Lint
+        run: ruff check .
       - name: Run tests
         run: pytest -q
       - name: Benchmark


### PR DESCRIPTION
## Summary
- run Ruff linter in CI after installing dependencies

## Testing
- `ruff check .` *(fails: E402 Module level import not at top of file, etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68ad459f84f8832cbc75e17737ca4b22