### PR TITLE
chore: expand env example variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,8 @@ DEBUG=false
 LLM_URL=http://localhost:8000
 EMB_MODEL_NAME=sentence-transformers/sbert_large_nlu_ru
 RERANK_MODEL_NAME=sbert_cross_ru
-REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
+# Full Redis connection URL; rebuild as redis://:<password>@redis:6379/0 after changing REDIS_PASSWORD
+REDIS_URL=redis://:371c47186a2c55c7@redis:6379/0
 QDRANT_URL=http://qdrant:6333
 DOMAIN=mmvs.ru
 
@@ -46,6 +47,7 @@ DOMAIN=mmvs.ru
 MONGO_HOST=mongo
 MONGO_PORT=27017
 MONGO_ROOT_USERNAME=root
+# Generate passwords with `openssl rand -base64 16`
 MONGO_ROOT_PASSWORD=51c16BxU5Lm8520X
 MONGO_USERNAME=root
 MONGO_PASSWORD=51c16BxU5Lm8520X
@@ -55,18 +57,20 @@ MONGO_CONTEXTS=contexts
 MONGO_PRESETS=contextPresets
 MONGO_VECTORS=vectors
 MONGO_DOCUMENTS=documents
-MONGO_URI=mongodb://root:51c16BxU5Lm8520X@mongo:27017
+MONGO_URI=mongodb://root:51c16BxU5Lm8520X@mongo:27017 # Rebuild as mongodb://<user>:<password>@mongo:27017 if passwords change
 
 # Redis options
 REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_SECURE=false
+# Generate with `openssl rand -hex 16`
 REDIS_PASSWORD=371c47186a2c55c7
 REDIS_VECTOR=vector
 
 # Celery broker settings
-CELERY_BROKER=redis://:${REDIS_PASSWORD}@redis:6379/0
-CELERY_RESULT=redis://:${REDIS_PASSWORD}@redis:6379/0
+# Rebuild after changing REDIS_PASSWORD: redis://:<password>@redis:6379/0
+CELERY_BROKER=redis://:371c47186a2c55c7@redis:6379/0
+CELERY_RESULT=redis://:371c47186a2c55c7@redis:6379/0
 
 # Observability
 GRAFANA_PASSWORD=c3a3448776605163


### PR DESCRIPTION
## Summary
- inline Redis connection URLs
- document how to regenerate secrets and rebuild URLs

## Testing
- `pre-commit run --files .env.example` *(fails: command not found)*
- `pytest` *(fails: No module named 'redis', 'observability.metrics', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ad459e0e60832c898932a2b7bfd348