### PR TITLE
Protect admin password with SHA256 digest and constant-time compare

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ WEB_CONCURRENCY=1
 APP_MODULE=app.main:app
 HEALTHCHECK_URL=http://127.0.0.1:8000/healthz
 
+# Basic auth for admin panel
+ADMIN_USERNAME=admin
+# SHA256 hash of the default password "admin"
+ADMIN_PASSWORD=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
+
 # =========================
 # LLM / Options
 # =========================

--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 import base64
+import hashlib
+import hmac
 import os
 
 from fastapi import FastAPI
@@ -35,7 +37,9 @@ configure_logging()
 settings = Settings()
 
 ADMIN_USER = os.getenv("ADMIN_USERNAME", "admin")
-ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "admin")
+ADMIN_PASSWORD_DIGEST = bytes.fromhex(
+    os.getenv("ADMIN_PASSWORD", hashlib.sha256(b"admin").hexdigest())
+)
 
 
 class BasicAuthMiddleware(BaseHTTPMiddleware):
@@ -47,8 +51,10 @@ class BasicAuthMiddleware(BaseHTTPMiddleware):
                     encoded = auth.split(" ", 1)[1]
                     decoded = base64.b64decode(encoded).decode()
                     username, password = decoded.split(":", 1)
-                    if username == ADMIN_USER and password == ADMIN_PASSWORD:
-                        return await call_next(request)
+                    if username == ADMIN_USER:
+                        hashed = hashlib.sha256(password.encode()).digest()
+                        if hmac.compare_digest(hashed, ADMIN_PASSWORD_DIGEST):
+                            return await call_next(request)
                 except Exception:  # noqa: BLE001
                     pass
             return Response(status_code=401, headers={"WWW-Authenticate": "Basic"})


### PR DESCRIPTION
## Summary
- Hash admin password with SHA256 at startup and compare using `hmac.compare_digest`
- Document hashed ADMIN_PASSWORD in example `.env`

## Testing
- `ruff check app.py`
- `python -m pytest` *(fails: No module named 'httpx', 'starlette', 'bson')*


------
https://chatgpt.com/codex/tasks/task_e_68ad459dc7b8832c8519e077919b5644