### PR TITLE
Use redis password in Redis healthcheck

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -34,12 +34,7 @@ services:
       - "6379:6379"
     healthcheck:
       <<: *health_defaults
-      test:
-        - CMD
-        - redis-cli
-        - -a
-        - ${REDIS_PASSWORD}
-        - ping
+      test: ["CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD} ping"]
 
   celery_worker:
     # Processes scheduled tasks that update the vector store


### PR DESCRIPTION
## Summary
- authenticate Redis healthcheck using password

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68ad5e9ceea4832cb0ea770052c651b8