### PR TITLE
Use wget for qdrant healthcheck

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -150,7 +150,7 @@ services:
       - qdrant_data:/qdrant/storage
     healthcheck:
       <<: *health_defaults
-      test: ["CMD-SHELL", "curl -fsS http://localhost:6333/ready || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:6333/readyz || exit 1"]
 
 
   telegram-bot:


### PR DESCRIPTION
## Summary
- update qdrant service healthcheck to use `/readyz` endpoint
- switch command to `wget` to avoid missing `curl` in qdrant image

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'redis')*
- `docker-compose up -d qdrant` *(fails: Invalid interpolation format for "healthcheck" option in service "celery_worker": "test $(pgrep -fc celery) -ge 1")*

------
https://chatgpt.com/codex/tasks/task_e_68ada901ca14832cb847b1731ed69c9f